### PR TITLE
System: Disallow hibernation through polkit

### DIFF
--- a/src/login/org.freedesktop.login1.policy.in
+++ b/src/login/org.freedesktop.login1.policy.in
@@ -242,9 +242,9 @@
                 <_description>Hibernate the system</_description>
                 <_message>Authentication is required for hibernating the system.</_message>
                 <defaults>
-                        <allow_any>auth_admin_keep</allow_any>
-                        <allow_inactive>auth_admin_keep</allow_inactive>
-                        <allow_active>yes</allow_active>
+                        <allow_any>no</allow_any>
+                        <allow_inactive>no</allow_inactive>
+                        <allow_active>no</allow_active>
                 </defaults>
         </action>
 
@@ -252,9 +252,9 @@
                 <_description>Hibernate the system while other users are logged in</_description>
                 <_message>Authentication is required for hibernating the system while other users are logged in.</_message>
                 <defaults>
-                        <allow_any>auth_admin_keep</allow_any>
-                        <allow_inactive>auth_admin_keep</allow_inactive>
-                        <allow_active>auth_admin_keep</allow_active>
+                        <allow_any>no</allow_any>
+                        <allow_inactive>no</allow_inactive>
+                        <allow_active>no</allow_active>
                 </defaults>
                 <annotate key="org.freedesktop.policykit.imply">org.freedesktop.login1.hibernate</annotate>
         </action>


### PR DESCRIPTION
Since we don't allow hibernation, the easiest way to remove this option
from UI methods is by disabling it's use in PolicyKit. This should cover
the hibernate button as well but that part might need some testing.

[endlessm/eos-shell#2455]
