### PR TITLE
systemd-fsck@: Don't output to console

### DIFF
--- a/units/systemd-fsck@.service.in
+++ b/units/systemd-fsck@.service.in
@@ -17,5 +17,4 @@ Before=shutdown.target
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=@rootlibexecdir@/systemd-fsck %f
-StandardOutput=journal+console
 TimeoutSec=0


### PR DESCRIPTION
Informational fsck messages are currently printed to the console,
preventing silent boot.

Upstream commit 66f2ff06ca4ee5ea686b884e2923a31832ad8fe4 changes
this behaviour (I think) - at least I can't see how regular fsck
messages would end up on the console under the new fsckd setup.
So it should be OK to consider this patch already merged upstream.

[endlessm/eos-shell#2109]