### PR TITLE
core: Remove explicit Plymouth integration

### DIFF
--- a/src/core/main.c
+++ b/src/core/main.c
@@ -1567,7 +1567,7 @@ int main(int argc, char *argv[]) {
         if (arg_running_as == SYSTEMD_SYSTEM && !skip_setup) {
                 locale_setup();
 
-                if (arg_show_status || plymouth_running())
+                if (arg_show_status > 0)
                         status_welcome();
 
 #ifdef HAVE_KMOD

--- a/src/core/manager.c
+++ b/src/core/manager.c
@@ -2681,10 +2681,7 @@ static bool manager_get_show_status(Manager *m) {
         if (m->show_status)
                 return true;
 
-        /* If Plymouth is running make sure we show the status, so
-         * that there's something nice to see when people press Esc */
-
-        return plymouth_running();
+        return false;
 }
 
 void manager_status_printf(Manager *m, bool ephemeral, const char *status, const char *format, ...) {

--- a/src/fsck/fsck.c
+++ b/src/fsck/fsck.c
@@ -152,7 +152,7 @@ static void test_files(void) {
         }
 #endif
 
-        if (access("/run/systemd/show-status", F_OK) >= 0 || plymouth_running())
+        if (access("/run/systemd/show-status", F_OK) >= 0)
                 arg_show_progress = true;
 }
 

--- a/src/shared/util.c
+++ b/src/shared/util.c
@@ -3785,10 +3785,6 @@ bool nulstr_contains(const char*nulstr, const char *needle) {
         return false;
 }
 
-bool plymouth_running(void) {
-        return access("/run/plymouth/pid", F_OK) >= 0;
-}
-
 char* strshorten(char *s, size_t l) {
         assert(s);
 

--- a/src/shared/util.h
+++ b/src/shared/util.h
@@ -408,8 +408,6 @@ int kill_and_sigcont(pid_t pid, int sig);
 
 bool nulstr_contains(const char*nulstr, const char *needle);
 
-bool plymouth_running(void);
-
 bool hostname_is_valid(const char *s) _pure_;
 char* hostname_cleanup(char *s, bool lowercase);
 


### PR DESCRIPTION
Even if plymouth is running, it might have not displayed the splash yet,
so we'll see a few lines on fbcon when we should have otherwise had
nothing.

Plymouth integration was added to systemd in commit
6faa11140bf776cdaeb8d22d01816e6e48296971. That same day, Plymouth got
systemd integration [0]. As such, the Plymouth integration has always
been obsolete, and was probably only for older Plymouth's. But I can't
imagine anybody running a Plymouth from 2011 with a systemd from 2015.

Remove the Plymouth/systemd integration, and let Plymouth's code tell
systemd to print the details.

[0] http://cgit.freedesktop.org/plymouth/commit/?id=537c16422cd49f1beeaab1ad39846a00018faec1

Signed-off-by: Jasper St. Pierre <jstpierre@mecheye.net>

https://github.com/endlessm/eos-shell/issues/2109