### PR TITLE
Revert "Bring tmpfiles.d/tmp.conf in line with Debian defaults.  Closes:...

### DIFF
--- a/tmpfiles.d/tmp.conf
+++ b/tmpfiles.d/tmp.conf
@@ -8,8 +8,8 @@
 # See tmpfiles.d(5) for details
 
 # Clear tmp directories separately, to make them easier to override
-D /tmp 1777 root root -
-#d /var/tmp 1777 root root 30d
+d /tmp 1777 root root 10d
+d /var/tmp 1777 root root 30d
 
 # Exclude namespace mountpoints created with PrivateTmp=yes
 x /tmp/systemd-private-*


### PR DESCRIPTION
... #675422"

This reverts commit 68497cc9ad62aea73f1096856265a447f18dc074. Our users
have no need for this legacy Debian behavior, and we definitely want to
be cleaning the temporary directories occasionally to save space.

Conflicts:
	tmpfiles.d/tmp.conf

[endlessm/eos-shell#4757]