### PR TITLE
Disable resolved, networkd, timesyncd

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -24,6 +24,9 @@ CONFFLAGS = \
 	--enable-vconsole \
 	--disable-microhttpd \
 	--disable-sysusers \
+	--disable-networkd \
+	--disable-resolved \
+	--disable-timesyncd \
 	--disable-silent-rules \
 	--with-ntp-servers="0.debian.pool.ntp.org 1.debian.pool.ntp.org 2.debian.pool.ntp.org 3.debian.pool.ntp.org"  \
 	--with-system-uid-max=999 \

--- a/debian/systemd.postinst
+++ b/debian/systemd.postinst
@@ -89,12 +89,12 @@ systemd-machine-id-setup
 # Setup system users and groups
 addgroup --quiet --system systemd-journal
 
-adduser --quiet --system --group --no-create-home --home /run/systemd \
-    --gecos "systemd Time Synchronization" systemd-timesync
-adduser --quiet --system --group --no-create-home --home /run/systemd/netif \
-    --gecos "systemd Network Management" systemd-network
-adduser --quiet --system --group --no-create-home --home /run/systemd/resolve \
-    --gecos "systemd Resolver" systemd-resolve
+#adduser --quiet --system --group --no-create-home --home /run/systemd \
+#    --gecos "systemd Time Synchronization" systemd-timesync
+#adduser --quiet --system --group --no-create-home --home /run/systemd/netif \
+#    --gecos "systemd Network Management" systemd-network
+#adduser --quiet --system --group --no-create-home --home /run/systemd/resolve \
+#    --gecos "systemd Resolver" systemd-resolve
 adduser --quiet --system --group --no-create-home --home /run/systemd \
     --gecos "systemd Bus Proxy" systemd-bus-proxy
 
@@ -118,9 +118,9 @@ fi
 if [ -n "$2" ]; then
     _systemctl daemon-reexec || true
     _systemctl try-restart systemd-logind.service || true
-    _systemctl try-restart systemd-networkd.service || true
-    _systemctl try-restart systemd-resolved.service || true
-    _systemctl try-restart systemd-timesyncd.service || true
+    #_systemctl try-restart systemd-networkd.service || true
+    #_systemctl try-restart systemd-resolved.service || true
+    #_systemctl try-restart systemd-timesyncd.service || true
 fi
 
 # Enable getty and remote-fs.target by default on new installs, and on

--- a/debian/systemd.preinst
+++ b/debian/systemd.preinst
@@ -47,16 +47,16 @@ if [ "$1" = "install" ] || [ "$1" = "upgrade" ] && dpkg --compare-versions "$2" 
     if dpkg --compare-versions "$2" ge "204-8~" ; then
         save_is_enabled tmp.mount
     fi
-    if dpkg --compare-versions "$2" ge "209" ; then
-        save_is_enabled systemd-networkd.service
-    fi
-    if dpkg --compare-versions "$2" ge "211" ; then
-        save_is_enabled systemd-networkd-wait-online.service
-    fi
-    if dpkg --compare-versions "$2" ge "213" ; then
-        save_is_enabled systemd-resolved.service
-        save_is_enabled systemd-timesyncd.service
-    fi
+    #if dpkg --compare-versions "$2" ge "209" ; then
+    #    save_is_enabled systemd-networkd.service
+    #fi
+    #if dpkg --compare-versions "$2" ge "211" ; then
+    #    save_is_enabled systemd-networkd-wait-online.service
+    #fi
+    #if dpkg --compare-versions "$2" ge "213" ; then
+    #    save_is_enabled systemd-resolved.service
+    #    save_is_enabled systemd-timesyncd.service
+    #fi
 fi
 
 #DEBHELPER#


### PR DESCRIPTION
Disable networkd: not needed here, we use NetworkManager

Disable resolved: only used by networkd at this time

Disable timesyncd: sounds perfect for Endless, but lets wait for it
to mature first, before we replace ntp. Searching around, there are many
bug reports for this. There are several important-looking fixes that only
went in after v215. It only seems to integrate well with networkd; ntp may
do a better job of watching network connectivity here (need to
check/compare).

[endlessm/eos-shell#4900]