### PR TITLE
tmpfiles.d: disable systemd-networkd entries

### DIFF
--- a/tmpfiles.d/systemd.conf
+++ b/tmpfiles.d/systemd.conf
@@ -16,9 +16,9 @@ d /run/systemd/sessions 0755 root root -
 d /run/systemd/users 0755 root root -
 d /run/systemd/machines 0755 root root -
 d /run/systemd/shutdown 0755 root root -
-d /run/systemd/netif 0755 systemd-network systemd-network -
-d /run/systemd/netif/links 0755 systemd-network systemd-network -
-d /run/systemd/netif/leases 0755 systemd-network systemd-network -
+#d /run/systemd/netif 0755 systemd-network systemd-network -
+#d /run/systemd/netif/links 0755 systemd-network systemd-network -
+#d /run/systemd/netif/leases 0755 systemd-network systemd-network -
 
 d /run/log 0755 root root -
 


### PR DESCRIPTION
As we're building without networkd support, we don't have this
user account.

Comment out these entries, to solve a tmpfiles.d error during boot,
which may also be preventing other tmpfiles.d entries from activating.

[endlessm/eos-shell#4900]