### PR TITLE
shared: Implement a [white/black]list mechanism for sleep operations

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -880,6 +880,9 @@ libsystemd_shared_la_CFLAGS = \
 	$(SECCOMP_CFLAGS) \
 	-pthread
 
+dist_pkgsysconf_DATA += \
+	src/shared/sleep-products.conf
+
 # ------------------------------------------------------------------------------
 noinst_LTLIBRARIES += \
 	libsystemd-units.la

--- a/src/shared/sleep-config.c
+++ b/src/shared/sleep-config.c
@@ -21,6 +21,10 @@
 
 #include <stdio.h>
 
+#include "sd-bus.h"
+
+#include "bus-util.h"
+#include "bus-error.h"
 #include "conf-parser.h"
 #include "sleep-config.h"
 #include "fileio.h"
@@ -104,6 +108,56 @@ int parse_sleep_config(const char *verb, char ***_modes, char ***_states) {
 
         *_modes = modes;
         *_states = states;
+        return 0;
+}
+
+static int parse_sleep_products_config(const char *verb, char ***_blacklist, char ***_whitelist) {
+
+        _cleanup_strv_free_ char
+                **suspend_blacklist = NULL, **suspend_whitelist = NULL,
+                **hibernate_blacklist = NULL, **hibernate_whitelist = NULL,
+                **hybrid_blacklist = NULL, **hybrid_whitelist = NULL;
+        char **blacklist, **whitelist;
+
+        const ConfigTableItem items[] = {
+                { "CanSuspend",     "BlackListProducts", config_parse_strv,  0, &suspend_blacklist  },
+                { "CanSuspend",     "WhiteListProducts", config_parse_strv,  0, &suspend_whitelist },
+                { "CanHibernate",   "BlackListProducts", config_parse_strv,  0, &hibernate_blacklist  },
+                { "CanHibernate",   "WhiteListProducts", config_parse_strv,  0, &hibernate_whitelist },
+                { "CanHybridSleep", "BlackListProducts", config_parse_strv,  0, &hybrid_blacklist  },
+                { "CanHybridSleep", "WhiteListProducts", config_parse_strv,  0, &hybrid_whitelist },
+                {}
+        };
+
+        int r;
+        _cleanup_fclose_ FILE *f;
+
+        f = fopen(PKGSYSCONFDIR "/sleep-products.conf", "re");
+        if (!f)
+                log_full(errno == ENOENT ? LOG_DEBUG: LOG_WARNING,
+                         "Failed to open configuration file " PKGSYSCONFDIR "/sleep-products.conf: %m");
+        else {
+                r = config_parse
+                        (NULL, PKGSYSCONFDIR "/sleep-products.conf", f, "CanSuspend\0CanHibernate\0CanHybridSleep\0",
+                                 config_item_table_lookup, (void*) items, false, false, NULL);
+                if (r < 0)
+                        log_warning("Failed to parse configuration file: %s", strerror(-r));
+        }
+
+        if (streq(verb, "suspend")) {
+                USE(blacklist, suspend_blacklist);
+                USE(whitelist, suspend_whitelist);
+        } else if (streq(verb, "hibernate")) {
+                USE(blacklist, hibernate_blacklist);
+                USE(whitelist, hibernate_whitelist);
+        } else if (streq(verb, "hybrid-sleep")) {
+                USE(blacklist, hybrid_blacklist);
+                USE(whitelist, hybrid_whitelist);
+        } else
+                assert_not_reached("what verb");
+
+        *_blacklist = blacklist;
+        *_whitelist = whitelist;
         return 0;
 }
 
@@ -256,8 +310,81 @@ static bool enough_memory_for_hibernation(void) {
         return r;
 }
 
+static bool is_product_listed(char **products) {
+        char **product;
+        int r;
+        _cleanup_free_ char *p = NULL;
+
+        if (strv_isempty(products))
+                return false;
+
+        if (access("/sys/class/dmi/id/product_name", R_OK) < 0)
+                return false;
+
+        r = read_one_line_file("/sys/class/dmi/id/product_name", &p);
+        if (r < 0)
+                return false;
+
+        STRV_FOREACH(product, products) {
+                size_t l, k;
+
+                l = strlen(p);
+                k = strlen(*product);
+                if (l == k && memcmp(p, *product, l) == 0)
+                        return true;
+        }
+
+        return false;
+}
+
+static bool is_laptop_chassis(void) {
+        _cleanup_bus_unref_ sd_bus *bus = NULL;
+        _cleanup_bus_message_unref_ sd_bus_message *reply = NULL;
+        _cleanup_bus_error_free_ sd_bus_error error = SD_BUS_ERROR_NULL;
+        static int result = -1;
+        const char *s;
+        int r;
+
+        /* This answer depends on the actual hardware
+           so it won't change in subsequent calls. */
+        if (result != -1)
+                return result;
+
+        r = sd_bus_open_system(&bus);
+        if (r < 0) {
+                log_error("Failed to create bus connection: %s", strerror(-r));
+                goto finish;
+        }
+
+        r = sd_bus_get_property(
+                        bus,
+                        "org.freedesktop.hostname1",
+                        "/org/freedesktop/hostname1",
+                        "org.freedesktop.hostname1",
+                        "Chassis",
+                        &error, &reply, "s");
+        if (r < 0) {
+                log_error("Could not get property: %s", bus_error_message(&error, -r));
+                goto finish;
+        }
+
+        r = sd_bus_message_read(reply, "s", &s);
+        if (r < 0) {
+                bus_log_parse_error(r);
+                goto finish;
+        }
+
+        result = strcmp(s, "laptop") == 0;
+finish:
+        sd_bus_close(bus);
+
+        /* This can be -1 if the chassis could not be checked */
+        return result > 0;
+}
+
 int can_sleep(const char *verb) {
         _cleanup_strv_free_ char **modes = NULL, **states = NULL;
+        _cleanup_strv_free_ char **blacklist = NULL, **whitelist = NULL;
         int r;
 
         assert(streq(verb, "suspend") ||
@@ -269,6 +396,20 @@ int can_sleep(const char *verb) {
                 return false;
 
         if (!can_sleep_state(states) || !can_sleep_disk(modes))
+                return false;
+
+        /* We keep an optional white and black list (by product) to
+         * control if we want to explicitly support sleep operations. */
+        r = parse_sleep_products_config(verb, &blacklist, &whitelist);
+        if (r < 0)
+                return false;
+
+        if (is_product_listed(blacklist))
+                return false;
+
+        /* We don't support sleep operations for non-laptop chassis
+           unless the product has been explicitly white listed. */
+        if (!is_laptop_chassis() && !is_product_listed(whitelist))
                 return false;
 
         return streq(verb, "suspend") || enough_memory_for_hibernation();

--- a/src/shared/sleep-products.conf
+++ b/src/shared/sleep-products.conf
@@ -1,0 +1,35 @@
+#  This file is part of Endless's fork of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+#
+#  The contents of this file allow implementing a mechanism to blacklist
+#  certain products from supporting sleep operations, as well as to whitelist
+#  others that would be blacklisted by default: everything but laptops.
+#
+#  To achieve that, up to three sections can be defined here, controlling
+#  what gets blacklisted/whitelisted for each sleep operation. Each of those
+#  three sections can contain up to two variables, 'BlackListProducts' and
+#  'WhiteListProducts, listing the product names as exposed byt the kernel
+#  via the /sys/class/dmi/id/product_name file.
+#
+#  The example below shows how we could blacklist two laptops and whitelist
+#  one desktop computer, so that we can invert the default behaviour:
+#
+#  [CanSuspend]
+#  WhiteListProducts=GB-BXBT-2807
+#  BlackListProducts=20AQ0069UK 3249CTO
+#
+#  [CanHibernate]
+#  WhiteListProducts=GB-BXBT-2807
+#  BlackListProducts=20AQ0069UK 3249CTO
+#
+#  [CanHybridSleep]
+#  WhiteListProducts=GB-BXBT-2807
+#  BlackListProducts=20AQ0069UK 3249CTO
+#
+#  Note: All the sections and variables are optional
+
+


### PR DESCRIPTION
The idea behind here is that we would check, whenever someone asked
logind whether CanSuspend, CanHibernate or CanHybridSleep:

  1. Return false if the current machine's product name is blacklisted.

  2. Return false if the current machine's product name is not a laptop
    (does not have a battery) AND is not explicitly whitelisted.

  3. Fallback to the default logic if neither (1) nor (2) apply.

The blacklist and whitelist database would be stored via a configuration
file in /etc/systemd/sleep-products.conf, with its content organized in
sections, listing the product names (as taken from the DMI table) we
want to blacklist or white list for each sleep operation.

Neither this file nor its contents are mandatory, but if it exists, it
would look something like this (not all the sections mandatory either):

   [CanSuspend]
   BlackListProducts=ProductNameA ProductNameB
   WhiteListProducts=ProductNameC

   [CanHibernate]
   BlackListProducts=ProductNameA ProductNameB ProductNameD

   [CanHybridSleep]
   WhiteListProducts=ProductNameA ProductNameE

That way we should be able to explicitly blacklist laptop models if we
know they have problems, as well as whitelist desktop computers when we
now they work fine and want to support them explicitly.

[endlessm/eos-shell#4655]