### PR TITLE
Add EOS service preset file

### DIFF
--- a/debian/50-eos.preset
+++ b/debian/50-eos.preset
@@ -1,0 +1,17 @@
+# Systemd unit file presets for EOS. We do not install a wildcard
+# "disable *" rule, so here we simply blacklist any units that aren't
+# desired. All others will be enabled by systemd.
+
+# Reverse systemd defaults
+disable systemd-timesyncd.service
+disable systemd-networkd.service
+disable systemd-resolved.service
+
+# Disable other unwanted units
+disable bluetooth-init.service
+disable NetworkManager-wait-online.service
+disable rtkit-daemon.service
+disable serial-getty@.service
+disable ssh*.service
+disable ssh.socket
+disable systemd-nspawn@.service

--- a/debian/systemd.install
+++ b/debian/systemd.install
@@ -46,3 +46,6 @@ usr/lib/sysctl.d/
 usr/lib/systemd/
 usr/lib/tmpfiles.d/
 usr/share/locale/
+
+# EOS unit file presets
+debian/50-eos.preset /lib/systemd/system-preset/


### PR DESCRIPTION
If systemd does not find a /etc/machine-id file during boot, it will
automatically set all units to a preset enabled or disabled state. If
units aren't matched in any preset files, they'll be enabled.

This file sets the policy for EOS. It simply disables any units that
aren't desired and lets systemd enable the rest (or use the policy in
its own 90-systemd.preset file). In that sense, we want newly installed
units to be enabled and will blacklist any units that are found to be
unwanted.

[endlessm/eos-shell#5134]