### PR TITLE
Disable 'split-usr' configure option

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -28,6 +28,7 @@ CONFFLAGS = \
 	--disable-resolved \
 	--disable-timesyncd \
 	--disable-silent-rules \
+	--disable-split-usr \
 	--with-ntp-servers="0.debian.pool.ntp.org 1.debian.pool.ntp.org 2.debian.pool.ntp.org 3.debian.pool.ntp.org"  \
 	--with-system-uid-max=999 \
 	--with-system-gid-max=999


### PR DESCRIPTION
This switch is used to ensure that systemd will work on systems where
/bin, /lib and /sbin directories are not symlinks to their /usr
counterparts. On Endless OS this switch causes an error on shutdown.

endlessm/eos-shell#5046