### PR TITLE
Run ldconfig after updates

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -128,7 +128,6 @@ override_dh_install:
 	find debian/install/ \( \
 		-name systemd-journal-catalog-update.service -o \
 		-name systemd-udev-hwdb-update.service -o \
-		-name ldconfig.service -o \
 		-name etc.conf \) -delete
 	# remove .so for deprecated compatibility libraries
 	rm -f debian/install/*/usr/lib/*/libsystemd-daemon.so

--- a/debian/rules
+++ b/debian/rules
@@ -125,7 +125,7 @@ override_dh_install:
 	rm -f debian/install/*/usr/lib/sysctl.d/50-default.conf
 	find debian/install/ -name '*.la' -delete
 	# remove files related to factory-reset feature
-	find debian/install/ \( -name 'systemd-update-done*' -o \
+	find debian/install/ \( \
 		-name systemd-journal-catalog-update.service -o \
 		-name systemd-udev-hwdb-update.service -o \
 		-name ldconfig.service -o \


### PR DESCRIPTION
Make use of systemd's ldconfig service that runs after updates to ensure that the system linker configuration is up to date in case ostree has not deployed the new one.

[endlessm/eos-shell#5364]