### PR TITLE
readahead: Explicitly add a mark on /usr when collecting /

### DIFF
--- a/src/readahead/readahead-collect.c
+++ b/src/readahead/readahead-collect.c
@@ -302,6 +302,16 @@ static int collect(const char *root) {
                 goto finish;
         }
 
+        /* HACK: Also add a mark on /usr, which is on a separate mount.
+         *
+         * https://github.com/endlessm/eos-shell/issues/5525 */
+        if (streq(root, "/") &&
+            fanotify_mark(fanotify_fd, FAN_MARK_ADD|FAN_MARK_MOUNT, FAN_OPEN, AT_FDCWD, "/usr") < 0) {
+                log_error("Failed to mark /usr: %m");
+                r = -errno;
+                goto finish;
+        }
+
         inotify_fd = open_inotify();
         if (inotify_fd < 0) {
                 r = inotify_fd;


### PR DESCRIPTION
readahead adds a fanotify mark on /, but that doesn't read into /usr
since it's on a separate mount under ostree. Since /usr contains all the
binaries, readahead without it is pretty useless.

If the root to collect is /, add another mark on /usr. Probably this
should check if it's a separate mount but actually the same device, but
this is good enough for now.

[endlessm/eos-shell#5525]