### PR TITLE
Disable systemd-rfkill

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -29,6 +29,7 @@ CONFFLAGS = \
 	--disable-timesyncd \
 	--disable-silent-rules \
 	--disable-split-usr \
+	--disable-rfkill \
 	--with-ntp-servers="0.debian.pool.ntp.org 1.debian.pool.ntp.org 2.debian.pool.ntp.org 3.debian.pool.ntp.org"  \
 	--with-system-uid-max=999 \
 	--with-system-gid-max=999


### PR DESCRIPTION
When a Bluetooth adapter loses power over suspend it is re-probed on
resume and systemd-rfkill will restore the rfkill state from the
previous boot instead of the one right before suspend. This really needs
to be fixed upstream, but for now we're better off disabling
systemd-rfkill.

[endlessm/eos-shell#5598]