### PR TITLE
Move /.readahead file to /var/.readahead

### DIFF
--- a/src/readahead/readahead-collect.c
+++ b/src/readahead/readahead-collect.c
@@ -253,9 +253,13 @@ static int collect(const char *root) {
 
         assert(root);
 
-        if (asprintf(&pack_fn, "%s/.readahead", root) < 0) {
-                r = log_oom();
-                goto finish;
+        if (arg_pack_file)
+            pack_fn = strdup(arg_pack_file);
+        else
+            asprintf(&pack_fn, "%s/.readahead", root);
+        if (!pack_fn) {
+            r = log_oom();
+            goto finish;
         }
 
         starttime = now(CLOCK_MONOTONIC);
@@ -517,7 +521,7 @@ done:
         on_btrfs = statfs(root, &sfs) >= 0 && F_TYPE_EQUAL(sfs.f_type, BTRFS_SUPER_MAGIC);
         log_debug("On btrfs: %s", yes_no(on_btrfs));
 
-        if (asprintf(&pack_fn_new, "%s/.readahead.new", root) < 0) {
+        if (asprintf(&pack_fn_new, "%s.new", pack_fn) < 0) {
                 r = log_oom();
                 goto finish;
         }

--- a/src/readahead/readahead-common.h
+++ b/src/readahead/readahead-common.h
@@ -31,6 +31,7 @@
 
 #define READAHEAD_PACK_FILE_VERSION ";VERSION=2\n"
 
+extern const char *arg_pack_file;
 extern unsigned arg_files_max;
 extern off_t arg_file_size_max;
 extern usec_t arg_timeout;

--- a/src/readahead/readahead-replay.c
+++ b/src/readahead/readahead-replay.c
@@ -136,8 +136,12 @@ static int replay(const char *root) {
 
         block_bump_request_nr(root);
 
-        if (asprintf(&pack_fn, "%s/.readahead", root) < 0)
-                return log_oom();
+        if (arg_pack_file)
+            pack_fn = strdup(arg_pack_file);
+        else
+            asprintf(&pack_fn, "%s/.readahead", root);
+        if (!pack_fn)
+            return log_oom();
 
         pack = fopen(pack_fn, "re");
         if (!pack) {

--- a/src/readahead/readahead.c
+++ b/src/readahead/readahead.c
@@ -32,6 +32,7 @@
 #include "build.h"
 #include "readahead-common.h"
 
+const char *arg_pack_file;
 unsigned arg_files_max = 16*1024;
 off_t arg_file_size_max = READAHEAD_FILE_SIZE_MAX;
 usec_t arg_timeout = 2*USEC_PER_MINUTE;
@@ -42,6 +43,7 @@ static int help(void) {
                "Collect read-ahead data on early boot.\n\n"
                "  -h --help                 Show this help\n"
                "     --version              Show package version\n"
+               "     --pack-file=PATH       Custom location for pack file\n"
                "     --files-max=INT        Maximum number of files to read ahead\n"
                "     --file-size-max=BYTES  Maximum size of files to read ahead\n"
                "     --timeout=USEC         Maximum time to spend collecting data\n\n\n",
@@ -51,6 +53,7 @@ static int help(void) {
                "Replay collected read-ahead data on early boot.\n\n"
                "  -h --help                 Show this help\n"
                "     --version              Show package version\n"
+               "     --pack-file=PATH       Custom location for pack file\n"
                "     --file-size-max=BYTES  Maximum size of files to read ahead\n\n\n",
                program_invocation_short_name);
 
@@ -67,6 +70,7 @@ static int parse_argv(int argc, char *argv[]) {
 
         enum {
                 ARG_VERSION = 0x100,
+                ARG_PACKFILE,
                 ARG_FILES_MAX,
                 ARG_FILE_SIZE_MAX,
                 ARG_TIMEOUT
@@ -75,6 +79,7 @@ static int parse_argv(int argc, char *argv[]) {
         static const struct option options[] = {
                 { "help",          no_argument,       NULL, 'h'                },
                 { "version",       no_argument,       NULL, ARG_VERSION        },
+                { "pack-file",     required_argument, NULL, ARG_PACKFILE       },
                 { "files-max",     required_argument, NULL, ARG_FILES_MAX      },
                 { "file-size-max", required_argument, NULL, ARG_FILE_SIZE_MAX  },
                 { "timeout",       required_argument, NULL, ARG_TIMEOUT        },
@@ -97,6 +102,12 @@ static int parse_argv(int argc, char *argv[]) {
                         puts(PACKAGE_STRING);
                         puts(SYSTEMD_FEATURES);
                         return 0;
+
+                case ARG_PACKFILE:
+                        arg_pack_file = strdup(optarg);
+                        if (!arg_pack_file)
+                                return log_oom();
+                        break;
 
                 case ARG_FILES_MAX:
                         if (safe_atou(optarg, &arg_files_max) < 0 || arg_files_max <= 0) {

--- a/units/systemd-readahead-collect.service.in
+++ b/units/systemd-readahead-collect.service.in
@@ -18,7 +18,7 @@ ConditionVirtualization=no
 
 [Service]
 Type=notify
-ExecStart=@rootlibexecdir@/systemd-readahead collect
+ExecStart=@rootlibexecdir@/systemd-readahead --pack-file /var/readahead collect
 RemainAfterExit=yes
 StandardOutput=null
 OOMScoreAdjust=1000

--- a/units/systemd-readahead-drop.service
+++ b/units/systemd-readahead-drop.service
@@ -8,11 +8,11 @@
 [Unit]
 Description=Drop Read-Ahead Data
 Documentation=man:systemd-readahead-replay.service(8)
-ConditionPathExists=/.readahead
+ConditionPathExists=/var/readahead
 
 [Service]
 Type=oneshot
-ExecStart=/bin/rm -f /.readahead
+ExecStart=/bin/rm -f /var/readahead
 
 [Install]
 WantedBy=system-update.target

--- a/units/systemd-readahead-replay.service.in
+++ b/units/systemd-readahead-replay.service.in
@@ -12,12 +12,12 @@ DefaultDependencies=no
 Conflicts=shutdown.target
 Before=sysinit.target shutdown.target
 ConditionPathExists=!/run/systemd/readahead/noreplay
-ConditionPathExists=/.readahead
+ConditionPathExists=/var/readahead
 ConditionVirtualization=no
 
 [Service]
 Type=notify
-ExecStart=@rootlibexecdir@/systemd-readahead replay
+ExecStart=@rootlibexecdir@/systemd-readahead --pack-file /var/readahead replay
 RemainAfterExit=yes
 StandardOutput=null
 OOMScoreAdjust=1000


### PR DESCRIPTION
This allows the root of the ostree deployment to be immutable
while preserving readahead functionality.

[endlessm/eos-shell#5190]