### PR TITLE
coredump.conf: default to storing no coredumps

### DIFF
--- a/src/journal/coredump.conf
+++ b/src/journal/coredump.conf
@@ -8,7 +8,7 @@
 # See coredump.conf(5) for details
 
 [Coredump]
-#Storage=external
+Storage=none
 #Compress=yes
 #ProcessSizeMax=2G
 #ExternalSizeMax=2G


### PR DESCRIPTION
This will take a lot of resources, so disable it by default until we
have a way to report them.

[endlessm/eos-shell#6048]