### PR TITLE
Disable coredump processing by default

### DIFF
--- a/debian/systemd.postinst
+++ b/debian/systemd.postinst
@@ -153,4 +153,7 @@ if dpkg --compare-versions "$2" lt-nl "215-3"; then
     _systemctl try-restart systemd-journald.service || true
 fi
 
+# Disable coredump generation by default
+echo "kernel.core_pattern = |/bin/false" > /etc/sysctl.d/50-coredump.conf
+
 #DEBHELPER#


### PR DESCRIPTION
This creates /etc/sysctl.d/50-coredump.conf to override
/lib/sysctl.d/50-coredump.conf sending coredump data to /bin/false.

To enabling the processing of coredumps by systemd-coredump again,
simply remove this file.