### PR TITLE
Fix preset/enable

### DIFF
--- a/src/shared/conf-parser.c
+++ b/src/shared/conf-parser.c
@@ -727,7 +727,7 @@ int config_parse_strv(const char *unit,
         for (;;) {
                 char *word = NULL;
                 int r;
-                r = extract_first_word(&rvalue, &word, WHITESPACE, EXTRACT_QUOTES);
+                r = extract_first_word(&rvalue, &word, WHITESPACE, EXTRACT_QUOTES|EXTRACT_RETAIN_ESCAPE);
                 if (r == 0)
                         break;
                 if (r == -ENOMEM)

--- a/src/shared/install.c
+++ b/src/shared/install.c
@@ -2193,7 +2193,7 @@ static int execute_preset(
                 int q;
 
                 /* Returns number of symlinks that where supposed to be installed. */
-                q = install_context_apply(scope, plus, paths, config_path, root_dir, force, SEARCH_LOAD, changes, n_changes);
+                q = install_context_apply(scope, plus, paths, config_path, root_dir, force, SEARCH_LOAD|SEARCH_FOLLOW_CONFIG_SYMLINKS, changes, n_changes);
                 if (r >= 0) {
                         if (q < 0)
                                 r = q;


### PR DESCRIPTION
Allow running preset-all with existing symlinks in /etc, and properly handle escape unit names in unit files.

https://phabricator.endlessm.com/T6363