### PR TITLE
debian/extra/60-keyboard.hwdb: Yoga laptops touchpad-toggle keyboard quirk

### DIFF
--- a/debian/extra/60-keyboard.hwdb
+++ b/debian/extra/60-keyboard.hwdb
@@ -584,6 +584,14 @@ keyboard:dmi:bvn*:bvr*:svnLENOVO*:pn*IdeaPad*Z370*:pvr*
 keyboard:dmi:bvn*:bvr*:bd*:svnLENOVO*:pn*Lenovo*V480*:pvr*
  KEYBOARD_KEY_f1=f21
 
+# Yoga 3 Pro 2
+keyboard:dmi:bvn*:bvr*:bd*:svnLENOVO:pn80HE:pvr*
+ KEYBOARD_KEY_be=f21                                    # touchpad toggle
+
+# Yoga 900
+keyboard:dmi:bvn*:bvr*:bd*:svnLENOVO:pn80MK:pvr*
+ KEYBOARD_KEY_bf=f21                                    # touchpad toggle
+
 # enhanced USB keyboard
 keyboard:usb:v04B3p301B*
  KEYBOARD_KEY_90001=prog1 # ThinkVantage


### PR DESCRIPTION
This fix have been developed and applied on the mainline branch for
master, and cherry-picked for eos2.6. But on this systemd version Debian
overwrites the 60-keyboard.hwdb file with it own version, without the
fixes.

This commit copies the fixes from the eos2.6 branch to the
debian/extra/60-keyboard.hwdb file.

https://phabricator.endlessm.com/T10819