### PR TITLE
Revert touchpad-toggle hotkey fixes on 2.6

### DIFF
--- a/hwdb/60-keyboard.hwdb
+++ b/hwdb/60-keyboard.hwdb
@@ -580,10 +580,6 @@ keyboard:dmi:bvn*:bvr*:svnLENOVO*:pn*IdeaPad*Z370*:pvr*
 keyboard:dmi:bvn*:bvr*:bd*:svnLENOVO*:pn*Lenovo*V480*:pvr*
  KEYBOARD_KEY_f1=f21
 
-# Yoga 3 Pro 2
-keyboard:dmi:bvn*:bvr*:bd*:svnLENOVO:pn80HE:pvr*
- KEYBOARD_KEY_be=f21                                    # touchpad toggle
-
 # Yoga 900
 keyboard:dmi:bvn*:bvr*:bd*:svnLENOVO:pn80MK:pvr*
  KEYBOARD_KEY_bf=f21                                    # touchpad toggle

--- a/hwdb/60-keyboard.hwdb
+++ b/hwdb/60-keyboard.hwdb
@@ -580,10 +580,6 @@ keyboard:dmi:bvn*:bvr*:svnLENOVO*:pn*IdeaPad*Z370*:pvr*
 keyboard:dmi:bvn*:bvr*:bd*:svnLENOVO*:pn*Lenovo*V480*:pvr*
  KEYBOARD_KEY_f1=f21
 
-# Yoga 900
-keyboard:dmi:bvn*:bvr*:bd*:svnLENOVO:pn80MK:pvr*
- KEYBOARD_KEY_bf=f21                                    # touchpad toggle
-
 # enhanced USB keyboard
 keyboard:usb:v04B3p301B*
  KEYBOARD_KEY_90001=prog1 # ThinkVantage


### PR DESCRIPTION
These fixes regress T11082, so we decided to leave the touchpad-toggle hotkey not working on the 2.6 series and fix all the touchpad-related issues on master.

https://phabricator.endlessm.com/T10819
https://phabricator.endlessm.com/T11082