### PR TITLE
T11575: Add kbd as a dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -63,7 +63,8 @@ Depends: ${shlibs:Depends},
          util-linux (>= 2.27.1),
          mount (>= 2.26),
          adduser,
-         libcap2-bin
+         libcap2-bin,
+         kbd
 Breaks: lvm2 (<< 2.02.104-1),
         lsb-base (<< 4.1+Debian4),
         apparmor (<< 2.9.2-1),


### PR DESCRIPTION
We compile systemd with --enable-vconsole so we can ship
systemd-vconsole-setup, which uses loadkeys to setup the console
keyboard layout. loadkeys is provided by the kbd package, so we need to
make sure it gets installed.

https://phabricator.endlessm.com/T11575