### PR TITLE
[T10819] hwdb: Map 0xbe to F21 on the Yoga 900

### DIFF
--- a/hwdb/60-keyboard.hwdb
+++ b/hwdb/60-keyboard.hwdb
@@ -667,6 +667,7 @@ evdev:atkbd:dmi:bvn*:bvr*:bd*:svnLENOVO:pn80HE:pvr*
 # Yoga 900
 evdev:atkbd:dmi:bvn*:bvr*:bd*:svnLENOVO:pn80MK:pvr*
  KEYBOARD_KEY_bf=f21                                    # touchpad toggle
+ KEYBOARD_KEY_be=f21                                    # touchpad toggle
 
 # Lenovo Thinkcentre M800z AIO machine
 # key_scancode 00 is KEY_MICMUTE


### PR DESCRIPTION
Some Yoga 900 models emit 0xbe instead of 0xbf when the touchpad toggle
key is pressed, so we need to map it to KEY_TOUCHPAD_TOGGLE (F21) as
well.

https://phabricator.endlessm.com/T10819