### PR TITLE
base-filesystem: Only link /lib64 to /usr/lib64

### DIFF
--- a/src/shared/base-filesystem.c
+++ b/src/shared/base-filesystem.c
@@ -52,8 +52,7 @@ static const BaseFilesystem table[] = {
         { "var",   0755, NULL,                         NULL },
         { "etc",   0755, NULL,                         NULL },
 #if defined(__i386__) || defined(__x86_64__)
-        { "lib64",    0, "usr/lib/x86_64-linux-gnu\0"
-                         "usr/lib64\0",                "ld-linux-x86-64.so.2" },
+        { "lib64",    0, "usr/lib64\0",                "ld-linux-x86-64.so.2" },
 #endif
 };
 


### PR DESCRIPTION
In Debian's glibc package, ld-linux-x86-64.so.2 symlinks are created in /lib64
and /usr/lib/x86_64-linux-gnu. If /lib is a symlink to usr/lib and /lib64 is a
symlink to usr/lib/x86_64-linux-gnu, these links end up at the same path. In
that case, dpkg may remove them both on upgrade, making the system unusable
because there's no longer a /lib64/ld-linux-x86-64.so.2 linker available.

I'm not sure why you would ever want /lib64 -> usr/lib/x86_64-linux-gnu, but
it's definitely wrong on Endless. There should already be a /lib64 -> usr/lib64
symlink in place, but unfortunately eos-convert-system was missing support to
copy that from the deployment.

https://phabricator.endlessm.com/T11645