### PR TITLE
timedated: Control ntpd instead of systemd-timesyncd

### DIFF
--- a/src/timedate/timedated.c
+++ b/src/timedate/timedated.c
@@ -181,7 +181,7 @@ static int context_read_ntp(Context *c, sd_bus *bus) {
                         &error,
                         &reply,
                         "s",
-                        "systemd-timesyncd.service");
+                        "ntp.service");
 
         if (r < 0) {
                 if (sd_bus_error_has_name(&error, SD_BUS_ERROR_FILE_NOT_FOUND) ||
@@ -217,7 +217,7 @@ static int context_start_ntp(sd_bus *bus, sd_bus_error *error, bool enabled) {
                 error,
                 NULL,
                 "ss",
-                "systemd-timesyncd.service",
+                "ntp.service",
                 "replace");
         if (r < 0) {
                 if (sd_bus_error_has_name(error, SD_BUS_ERROR_FILE_NOT_FOUND) ||
@@ -247,7 +247,7 @@ static int context_enable_ntp(sd_bus *bus, sd_bus_error *error, bool enabled) {
                                 error,
                                 NULL,
                                 "asbb", 1,
-                                "systemd-timesyncd.service",
+                                "ntp.service",
                                 false, true);
         else
                 r = sd_bus_call_method(
@@ -259,7 +259,7 @@ static int context_enable_ntp(sd_bus *bus, sd_bus_error *error, bool enabled) {
                                 error,
                                 NULL,
                                 "asb", 1,
-                                "systemd-timesyncd.service",
+                                "ntp.service",
                                 false);
 
         if (r < 0) {


### PR DESCRIPTION
We do not ship systemd-timesyncd.

https://phabricator.endlessm.com/T11663