### PR TITLE
Revert "system.conf: enable more cgroups by default"

### DIFF
--- a/src/core/system.conf
+++ b/src/core/system.conf
@@ -12,7 +12,6 @@
 # See systemd-system.conf(5) for details.
 
 [Manager]
-DefaultControllers=cpu blkio memory
 #LogLevel=info
 #LogTarget=journal-or-kmsg
 #LogColor=yes


### PR DESCRIPTION
This reverts commit 6d1e1a2650f862b3ef5586550074598c732f3cc1. system.conf no
longer has a DefaultControllers option, and this just results in the warning
"Unknown lvalue 'DefaultControllers' in section 'Manager'" in the journal.