### PR TITLE
Disable hibernate and hybrid-sleep by default

### DIFF
--- a/src/shared/sleep-config.c
+++ b/src/shared/sleep-config.c
@@ -384,6 +384,7 @@ int can_sleep(const char *verb) {
         _cleanup_strv_free_ char **modes = NULL, **states = NULL;
         _cleanup_strv_free_ char **blacklist = NULL, **whitelist = NULL;
         int r;
+        bool whitelisted;
 
         assert(streq(verb, "suspend") ||
                streq(verb, "hibernate") ||
@@ -405,10 +406,17 @@ int can_sleep(const char *verb) {
         if (is_product_listed(blacklist))
                 return false;
 
+        whitelisted = is_product_listed(whitelist);
+
         /* We don't support sleep operations for non-laptop chassis
            unless the product has been explicitly white listed. */
-        if (!is_laptop_chassis() && !is_product_listed(whitelist))
+        if (!is_laptop_chassis() && !whitelisted)
                 return false;
 
-        return streq(verb, "suspend") || enough_memory_for_hibernation();
+        if (streq(verb, "suspend"))
+                return true;
+
+        /* Endless does not support hibernate or hybrid-sleep, see
+           T13184. So allow it only if whitelisted. */
+        return whitelisted && enough_memory_for_hibernation();
 }

--- a/src/shared/sleep-products.conf
+++ b/src/shared/sleep-products.conf
@@ -7,7 +7,8 @@
 #
 #  The contents of this file allow implementing a mechanism to blacklist
 #  certain products from supporting sleep operations, as well as to whitelist
-#  others that would be blacklisted by default: everything but laptops.
+#  others that would be blacklisted. By default, Endless allows only laptops to
+#  to suspend, and no products are allowed to hibernate.
 #
 #  To achieve that, up to three sections can be defined here, controlling
 #  what gets blacklisted/whitelisted for each sleep operation. Each of those
@@ -16,7 +17,7 @@
 #  via the /sys/class/dmi/id/product_name file.
 #
 #  The example below shows how we could blacklist two laptops and whitelist
-#  one desktop computer, so that we can invert the default behaviour:
+#  one desktop computer:
 #
 #  [CanSuspend]
 #  WhiteListProducts=GB-BXBT-2807


### PR DESCRIPTION
We will not support these operations, but continue to allow whitelisting
products with the existing configuration file because why not?

https://phabricator.endlessm.com/T13184