### PR TITLE
Add bus information for the Polywell Z83C Mini PC HDMI sound card

### DIFF
--- a/rules/78-sound-card.rules
+++ b/rules/78-sound-card.rules
@@ -86,4 +86,7 @@ ENV{ID_MODEL_FROM_DATABASE}=="*[Hh]andset*", ENV{SOUND_FORM_FACTOR}="handset", G
 ENV{ID_MODEL}=="*[Mm]icrophone*", ENV{SOUND_FORM_FACTOR}="microphone", GOTO="sound_end"
 ENV{ID_MODEL_FROM_DATABASE}=="*[Mm]icrophone*", ENV{SOUND_FORM_FACTOR}="microphone", GOTO="sound_end"
 
+# Quirk for the Polywell Z83C Mini PC
+DEVPATH=="/devices/platform/hdmi-audio/sound/card0", ENV{ID_BUS}="pci"
+
 LABEL="sound_end"


### PR DESCRIPTION
This is one of the properties used by pulseaudio to define sink
priority.

In this machine there are two cards present, the HDMI one, and another
connected over USB, for the external speaker and microphone connectors.
Without this patch the USB card has a higher priority than the HDMI one,
and since its ports are always available (no jack sensing support), it
is always the selected one.

With this change the HDMI gets a higher priority and is selected by
default.

https://phabricator.endlessm.com/T14071