### PR TITLE
udev: Tag cards from platform audio drivers as internal

### DIFF
--- a/rules/78-sound-card.rules
+++ b/rules/78-sound-card.rules
@@ -47,7 +47,13 @@ SUBSYSTEMS=="firewire", ATTRS{guid}=="?*", \
   ENV{ID_VENDOR}="$attr{vendor_name}", ENV{ID_MODEL}="$attr{model_name}"
 SUBSYSTEMS=="firewire", GOTO="skip_pci"
 
-SUBSYSTEMS=="pci", ENV{ID_BUS}="pci", ENV{ID_VENDOR_ID}="$attr{vendor}", ENV{ID_MODEL_ID}="$attr{device}"
+SUBSYSTEMS=="pci", ENV{ID_BUS}="pci", ENV{ID_VENDOR_ID}="$attr{vendor}", ENV{ID_MODEL_ID}="$attr{device}", GOTO="skip_pci"
+
+# If we reach here, the device nor any of its parents are USB/PCI/firewire bus devices.
+# If we now find a parent that is a platform device, assume that we're working with
+# an internal sound card.
+SUBSYSTEMS=="platform", ENV{SOUND_FORM_FACTOR}="internal", GOTO="sound_end"
+
 LABEL="skip_pci"
 
 # Define ID_ID if ID_BUS and ID_SERIAL are set. This will work for both


### PR DESCRIPTION
Sound cards in the platform subsystem are internal to the machine, so
they should be tagged as so. This is one of the properties used by
pulseaudio to define default sink priority.

https://phabricator.endlessm.com/T14071