### PR TITLE
rules: identify internal sound cards on platform bus

### DIFF
--- a/rules/78-sound-card.rules
+++ b/rules/78-sound-card.rules
@@ -48,6 +48,13 @@ SUBSYSTEMS=="firewire", ATTRS{guid}=="?*", \
 SUBSYSTEMS=="firewire", GOTO="skip_pci"
 
 SUBSYSTEMS=="pci", ENV{ID_BUS}="pci", ENV{ID_VENDOR_ID}="$attr{vendor}", ENV{ID_MODEL_ID}="$attr{device}"
+SUBSYSTEMS=="pci", GOTO="skip_pci"
+
+# If we reach here, the device nor any of its parents are USB/PCI/firewire bus devices.
+# If we now find a parent that is a platform device, assume that we're working with
+# an internal sound card.
+SUBSYSTEMS=="platform", ENV{SOUND_FORM_FACTOR}="internal", GOTO="sound_end"
+
 LABEL="skip_pci"
 
 # Define ID_ID if ID_BUS and ID_SERIAL are set. This will work for both


### PR DESCRIPTION
We have a system which has the HDMI audio capability internally,
but pulseaudio is not giving it a very high priority compared
to e.g. USB sound cards.

The sound device appears on the platform bus and it is not
currently tagged with any form factor information.

It seems safe to assume that any sound card that is directly on the
platform bus is of internal form factor, but we must be careful because
udev rules will match all parent devices, not just the immediate parent,
and you will frequently encounter setups such as:

 Platform bus -> USB host controller -> USB sound card

In that case, SUBSYSTEMS==platform would match even though we're
clearly working with an external USB sound card.

In order to detect true platform devices here, we rely on the observation
that if any parent devices of the sound card are PCI, USB or firewire
devices, then this sound card cannot directly connected to the platform
bus. Otherwise, if we find a parent device on the platform bus, we assume
this is an internal sound card connected directly to the platform bus.

https://phabricator.endlessm.com/T14071