### PR TITLE
hwdb: Fix airplane mode key for Acer Aspire models

### DIFF
--- a/hwdb/60-keyboard.hwdb
+++ b/hwdb/60-keyboard.hwdb
@@ -99,6 +99,7 @@ evdev:atkbd:dmi:bvn*:bvr*:bd*:svnAcer*:pnAspire*:pvr*
  KEYBOARD_KEY_84=bluetooth                              # sent when bluetooth module missing, and key pressed
  KEYBOARD_KEY_d9=bluetooth                              # Bluetooth off
  KEYBOARD_KEY_92=media                                  # Acer arcade
+ KEYBOARD_KEY_86=wlan					# Fn+F3 or Fn+Q for comunication key
 
 evdev:atkbd:dmi:bvn*:bvr*:bd*:svnAcer*:pnAspire*5720*:pvr*
 evdev:atkbd:dmi:bvn*:bvr*:bd*:svnAcer*:pnZG8*:pvr*


### PR DESCRIPTION
According to the key code v2.02 from Acer, scancode E0 86 will be
received for airplane mode hotkey.

https://phabricator.endlessm.com/T14825

Signed-off-by: Chris Chiu <chiu@endlessm.com>