### PR TITLE
persistent-storage: Enable 'blkid' for CDROM

### DIFF
--- a/rules/60-persistent-storage.rules
+++ b/rules/60-persistent-storage.rules
@@ -69,7 +69,7 @@ ENV{DEVTYPE}=="partition", ENV{ID_PATH}=="?*", SYMLINK+="disk/by-path/$env{ID_PA
 KERNEL=="sr*", ENV{DISK_EJECT_REQUEST}!="?*", ENV{ID_CDROM_MEDIA_TRACK_COUNT_DATA}=="?*", ENV{ID_CDROM_MEDIA_SESSION_LAST_OFFSET}=="?*", \
   IMPORT{builtin}="blkid --offset=$env{ID_CDROM_MEDIA_SESSION_LAST_OFFSET}"
 # single-session CDs do not have ID_CDROM_MEDIA_SESSION_LAST_OFFSET
-KERNEL=="sr*", ENV{DISK_EJECT_REQUEST}!="?*", ENV{ID_CDROM_MEDIA_TRACK_COUNT_DATA}=="?*", ENV{ID_CDROM_MEDIA_SESSION_LAST_OFFSET}=="", \
+KERNEL=="sr*", ENV{DISK_EJECT_REQUEST}!="?*", ENV{ID_CDROM_MEDIA_SESSION_LAST_OFFSET}=="", \
   IMPORT{builtin}="blkid --noraid"
 
 # probe filesystem metadata of disks


### PR DESCRIPTION
udisk (and udiskctl) relies on ID_FS_TYPE key when detecting the fs on
the CDROM. In our current setup ID_FS_TYPE is not set and udisk is
unable to detect any filesystem on the CDROM, refusing to mount it
using udiskctl (or programmatically).

ID_FS_TYPE (among other things) is set by 'blkid' in
60-persistent-storage.rules with the rule:

KERNEL=="sr*", ENV{DISK_EJECT_REQUEST}!="?*", \
 ENV{ID_CDROM_MEDIA_TRACK_COUNT_DATA}=="?*", \
 ENV{ID_CDROM_MEDIA_SESSION_LAST_OFFSET}=="", \
 MPORT{builtin}="blkid --noraid"

Unfortunately this rule is never matched/executed since
ID_CDROM_MEDIA_TRACK_COUNT_DATA is never set.

ID_CDROM_MEDIA_TRACK_COUNT_DATA should be set by 'cdrom_id' in
60-cdrom_id.rules but on our system 'cdrom_id /dev/sr0' fails with
-EBUSY.

The problem is that 'cdrom_id' tries to open /dev/sr0 using O_EXCL.
O_EXCL on block devices fails with EBUSY if, and only if, there's
someone else also opening the device with O_EXCL [1]. In our case this call
fails since we are already booting from /dev/sr0 keeping it already
opened with O_EXCL.

As suggested here [2] we fix this by not relying anymore on
ID_CDROM_MEDIA_TRACK_COUNT_DATA for executing 'blkid' and importing
ID_FS_*.

[1] https://lists.freedesktop.org/archives/systemd-devel/2014-September/023160.html
[2] https://lists.freedesktop.org/archives/systemd-devel/2014-September/023160.html

Signed-off-by: Carlo Caione <carlo@endlessm.com>