### PR TITLE
hwdb: Add power key(button) mapping for Acer models

### DIFF
--- a/hwdb/60-keyboard.hwdb
+++ b/hwdb/60-keyboard.hwdb
@@ -88,6 +88,7 @@ evdev:atkbd:dmi:bvn*:bvr*:bd*:svneMachines:pneMachines*E725:pvr*
  KEYBOARD_KEY_f3=prog2                                  # "P2" programmable button
  KEYBOARD_KEY_f4=prog1                                  # "P1" programmable button
  KEYBOARD_KEY_f5=presentation
+ KEYBOARD_KEY_f6=power                                  # Power button
  KEYBOARD_KEY_f8=fn
  KEYBOARD_KEY_f9=prog1                                  # Launch NTI shadow
 
@@ -115,9 +116,6 @@ evdev:atkbd:dmi:bvn*:bvr*:bd*:svnAcer*:pnAspire*8930:*
  KEYBOARD_KEY_83=rewind
  KEYBOARD_KEY_89=fastforward
  KEYBOARD_KEY_9e=back
-
-evdev:atkbd:dmi:bvn*:bvr*:bd*:svnAcer*:pnAspire*ES1-421:pvr*
- KEYBOARD_KEY_f6=power
 
 # Travelmate C300
 evdev:atkbd:dmi:bvn*:bvr*:bd*:svnAcer*:pnTravelMate*C3[01]0*:pvr*


### PR DESCRIPTION
Since the power key keycode e076 not only found on Aspire ES1-421,
but also other Aspire/Nitro laptops. Move the keycode mapping for
Acer models.

https://phabricator.endlessm.com/T16475

Signed-off-by: Chris Chiu <chiu@endlessm.com>