### PR TITLE
Unconditionally enable tmp.mount

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -202,11 +202,6 @@ endif
 			debian/systemd/lib/systemd/system/$${t}.target.wants ;\
 	done
 
-	# we don't want /tmp to be a tmpfs by default
-	mv debian/systemd/lib/systemd/system/tmp.mount debian/systemd/usr/share/systemd/
-	printf '\n[Install]\nWantedBy=local-fs.target\n' >> debian/systemd/usr/share/systemd/tmp.mount
-	rm debian/systemd/lib/systemd/system/local-fs.target.wants/tmp.mount
-
 	# files shipped by cryptsetup
 ifeq (, $(filter stage1, $(DEB_BUILD_PROFILES)))
 	rm debian/systemd/usr/share/man/man5/crypttab.5

--- a/debian/systemd.postinst
+++ b/debian/systemd.postinst
@@ -76,23 +76,6 @@ EOF
     fi
 fi
 
-# Do a one-time migration of the RAMTMP setting
-if dpkg --compare-versions "$2" lt "204-8"; then
-    if [ -f /etc/default/rcS ]; then
-        . /etc/default/rcS
-    fi
-    if [ -f /etc/default/tmpfs ]; then
-        . /etc/default/tmpfs
-    fi
-    if [ "$RAMTMP" = "yes" ]; then
-        # systemctl enable will work even when systemd is not the active PID 1.
-        if [ ! -e /etc/systemd/system/tmp.mount ]; then
-            cp /usr/share/systemd/tmp.mount /etc/systemd/system/tmp.mount
-            systemctl enable tmp.mount || true
-        fi
-    fi
-fi
-
 # Create /etc/machine-id
 systemd-machine-id-setup
 
@@ -111,16 +94,6 @@ setcap cap_dac_override,cap_sys_ptrace=ep /usr/bin/systemd-detect-virt || true
 # Re-run systemctl enable for any service that was enabled when preinst was run.
 if dpkg --compare-versions "$2" ge "204" && [ -e /run/systemd/was-enabled ]; then
     while read UNIT ; do
-        # 220-6 stopped shipping tmp.mount, transition it on machines which had
-        # it enabled
-        if [ "$UNIT" = tmp.mount ] && dpkg --compare-versions "$2" lt-nl "220-6~"; then
-            if [ ! -e /etc/systemd/system/tmp.mount ]; then
-                echo "moving enabled tmp.mount to /etc/systemd/system/..."
-                cp /usr/share/systemd/tmp.mount /etc/systemd/system/tmp.mount
-                # clean up the symlink, to have it re-created below
-                systemctl disable $UNIT
-            fi
-        fi
         systemctl enable $UNIT || true
     done </run/systemd/was-enabled || true
 fi

--- a/debian/tests/boot-and-services
+++ b/debian/tests/boot-and-services
@@ -96,16 +96,7 @@ class ServicesTest(unittest.TestCase):
         self.active_unit('systemd-udevd')
 
     def test_tmp_mount(self):
-        # check if we want to mount /tmp in fstab
-        want_tmp_mount = False
-        with open('/etc/fstab') as f:
-            for l in f:
-                try:
-                    if not l.startswith('#') and l.split()[1] in ('/tmp', '/tmp/'):
-                        want_tmp_mount = True
-                        break
-                except IndexError:
-                    pass
+        want_tmp_mount = True
 
         # ensure that we actually do/don't have a /tmp mount
         (status, status_out) = subprocess.getstatusoutput('systemctl status tmp.mount')


### PR DESCRIPTION
Previously, we depended on the "one-time migration" block in postinst to
read /etc/default/tmpfs and enable tmp.mount by copying it into /etc.
This behaviour is inherited from Debian where tmpfs-on-/tmp is not the
default. /etc/default/tmpfs is provided by the initscripts package,
which is no longer a required package and so is not included in the
first phase of debootstrap where the systemd package is installed.

Since we always want /tmp to be a tmpfs in Endless OS, we can just
remove this Debian-specific logic and follow upstream, where tmp.mount
is installed to /lib/systemd/system and symlinked into
/lib/systemd/system/local-fs.target.wants/. Assuming that users have not
modified either /etc/systemd/system/tmp.mount or
the /etc/systemd/system/local-fs.target.wants/tmp.mount symlink,
on an ostree upgrade these files in /etc should be removed, and the
copies in /lib will be used instead. On converted systems, we can just
leave them harmlessly in place.

https://phabricator.endlessm.com/T17850