### PR TITLE
eos.preset: disable peer-to-peer updater by default

### DIFF
--- a/debian/50-eos.preset
+++ b/debian/50-eos.preset
@@ -11,6 +11,10 @@ disable systemd-networkd-wait-online.service
 # Disable other unwanted units
 disable bluetooth-init.service
 disable eos-firewall-localonly.service
+disable eos-update-server.service
+disable eos-update-server.socket
+disable eos-updater-avahi.path
+disable eos-updater-avahi.service
 disable NetworkManager-wait-online.service
 disable rtkit-daemon.service
 disable serial-getty@.service


### PR DESCRIPTION
This is supposed to only be enabled on certain images, to which
/etc/systemd/system-preset/40-eos-update-server.preset is added at image
build time with:

  enable eos-update-server.socket
  enable eos-updater-avahi.path

But due to our enabled-unless-proven-guilty behaviour, they were in fact
enabled on all systems.

The daemon actually quits as soon as it is started if its config file
doesn't instruct it to advertise updates, so this is only a boot-time
performance problem, not a correctness problem.

https://phabricator.endlessm.com/T18824