### PR TITLE
gpt-auto-generator: Do not mount the ESP on non-EFI systems

### DIFF
--- a/src/gpt-auto-generator/gpt-auto-generator.c
+++ b/src/gpt-auto-generator/gpt-auto-generator.c
@@ -538,8 +538,10 @@ static int add_boot(const char *what) {
                         log_debug("Partition for %s does not appear to be the partition we are booted from.", esp);
                         return 0;
                 }
-        } else
-                log_debug("Not an EFI boot, skipping ESP check.");
+        } else {
+                log_debug("Not an EFI boot, ignoring the ESP.");
+                return 0;
+        }
 
         return add_automount("boot",
                           what,


### PR DESCRIPTION
We don't want to have the ESP automatically mounted on non-EFI systems,
as this has the side-effect of removing the /sysroot/boot -> /boot
bind-mount needed by OSTree systems which don't use a separate boot
partition.

This effectively reverts the change introduced by

  commit 7ba25ab5616339a8340117b85cbecd061c52d8cc
  Author: Lennart Poettering <lennart@poettering.net>
  Date:   Thu Jul 21 11:30:02 2016 +0200

  gpt-generator: relax EFI check a bit

  Previously, we'd not mount the ESP except on EFI boots, and only when the ESP
  used for booting matches the ESP we found.

  With this change on non-EFI boots we'll mount a discovered ESP anyway, and on
  EFI boots we'll only mount it if it matches the ESP we booted from.

https://phabricator.endlessm.com/T18825