### PR TITLE
shared: Disable suspend on Weibu F3C units

### DIFF
--- a/src/shared/sleep-products.conf
+++ b/src/shared/sleep-products.conf
@@ -33,4 +33,6 @@
 #
 #  Note: All the sections and variables are optional
 
+[CanSuspend]
+BlackListProducts=F3C EE-200 # https://phabricator.endlessm.com/T20298
 


### PR DESCRIPTION
There's a bug on Weibu F3C Mini PCs where suspend breaks WiFi support.
The fix for that (https://phabricator.endlessm.com/T20168) won't be
included in a stable EOS release in time for the next round of
production, so this commit disables suspend on this hardware
temporarily. The effect is that there's no Suspend option in Settings
(gnome-control-center) and pressing the power button prompts the user to
shut down rather than immediately suspending.

https://phabricator.endlessm.com/T20298