### PR TITLE
shared: Fix comment in sleep-products.conf

### DIFF
--- a/src/shared/sleep-products.conf
+++ b/src/shared/sleep-products.conf
@@ -34,5 +34,6 @@
 #  Note: All the sections and variables are optional
 
 [CanSuspend]
-BlackListProducts=F3C EE-200 # https://phabricator.endlessm.com/T20298
+# https://phabricator.endlessm.com/T20298
+BlackListProducts=F3C EE-200
 


### PR DESCRIPTION
The config file parser only allows full line comments, so change
sleep-products.conf to comply.

https://phabricator.endlessm.com/T20298