### PR TITLE
Set the maximum on-disk joural size to 50 MiB

### DIFF
--- a/src/journal/journald.conf
+++ b/src/journal/journald.conf
@@ -19,9 +19,9 @@
 #SyncIntervalSec=5m
 #RateLimitIntervalSec=30s
 #RateLimitBurst=1000
-#SystemMaxUse=
+SystemMaxUse=50M
 #SystemKeepFree=
-#SystemMaxFileSize=
+SystemMaxFileSize=1M
 #SystemMaxFiles=100
 RuntimeMaxUse=4M
 #RuntimeKeepFree=


### PR DESCRIPTION
This also sets the on-disk granularity to about 1 MiB per journal file.
When the maximum storage is used, journald will delete the oldest
journal file and allocate a new one to continue writing. Finer
granularity results in larger journal retention but more-frequent file
deletion and creation.

With these settings, this retains about 20k lines of messages which
roughly corresponds to 40 active hours on a relatively busy system.

For the purposes of classrooms, this would likely span multiple weeks.

NOTE: these changes only apply to the on-disk (persistent) journal and
that only gets used if /var/log/journal exists and is writable. That is
not true as of this writing but will soon be true for machines with
durable (non-MMC/-SD) storage.

https://phabricator.endlessm.com/T21771