### PR TITLE
T22718: make /dev/kvm 0666

### DIFF
--- a/rules/50-udev-default.rules.in
+++ b/rules/50-udev-default.rules.in
@@ -76,7 +76,7 @@ KERNEL=="tun", MODE="0666", OPTIONS+="static_node=net/tun"
 KERNEL=="fuse", MODE="0666", OPTIONS+="static_node=fuse"
 
 # The static_node is required on s390x and ppc (they are using MODULE_ALIAS)
-KERNEL=="kvm", GROUP="kvm", MODE="@DEV_KVM_MODE@", OPTIONS+="static_node=kvm"
+KERNEL=="kvm", MODE="@DEV_KVM_MODE@", OPTIONS+="static_node=kvm"
 
 SUBSYSTEM=="ptp", ATTR{clock_name}=="KVM virtual PTP", SYMLINK += "ptp_kvm"
 

--- a/rules/50-udev-default.rules.in
+++ b/rules/50-udev-default.rules.in
@@ -76,7 +76,7 @@ KERNEL=="tun", MODE="0666", OPTIONS+="static_node=net/tun"
 KERNEL=="fuse", MODE="0666", OPTIONS+="static_node=fuse"
 
 # The static_node is required on s390x and ppc (they are using MODULE_ALIAS)
-#KERNEL=="kvm", GROUP="kvm", MODE="@DEV_KVM_MODE@", OPTIONS+="static_node=kvm"
+KERNEL=="kvm", GROUP="kvm", MODE="@DEV_KVM_MODE@", OPTIONS+="static_node=kvm"
 
 SUBSYSTEM=="ptp", ATTR{clock_name}=="KVM virtual PTP", SYMLINK += "ptp_kvm"
 


### PR DESCRIPTION
Debian's patch to have /dev/kvm udev rules defined in a qemu package means we get no permissions set on /dev/kvm in Endless OS. Revert the Debian patch so we get 0666 permissions again, but remove the "kvm" group which is not defined in Endless.

https://phabricator.endlessm.com/T22718