### PR TITLE
core: don't include libmount.h in a header file (#8580)

### DIFF
--- a/src/core/dbus-execute.c
+++ b/src/core/dbus-execute.c
@@ -18,6 +18,7 @@
   along with systemd; If not, see <http://www.gnu.org/licenses/>.
 ***/
 
+#include <sys/mount.h>
 #include <sys/prctl.h>
 #include <stdio_ext.h>
 

--- a/src/core/manager.h
+++ b/src/core/manager.h
@@ -20,7 +20,6 @@
   along with systemd; If not, see <http://www.gnu.org/licenses/>.
 ***/
 
-#include <libmount.h>
 #include <stdbool.h>
 #include <stdio.h>
 
@@ -33,6 +32,8 @@
 #include "ip-address-access.h"
 #include "list.h"
 #include "ratelimit.h"
+
+struct libmnt_monitor;
 
 /* Enforce upper limit how many names we allow */
 #define MANAGER_MAX_NAMES 131072 /* 128K */

--- a/src/core/mount.c
+++ b/src/core/mount.c
@@ -23,6 +23,8 @@
 #include <stdio.h>
 #include <sys/epoll.h>
 
+#include <libmount.h>
+
 #include "sd-messages.h"
 
 #include "alloc-util.h"


### PR DESCRIPTION
linux/fs.h sys/mount.h, libmount.h and missing.h all include MS_*
definitions.

To avoid problems, only one of linux/fs.h, sys/mount.h and libmount.h
should be included. And missing.h must be included last.

Without this, building systemd may fail with:

In file included from [...]/libmount/libmount.h:31:0,
                 from ../systemd-238/src/core/manager.h:23,
                 from ../systemd-238/src/core/emergency-action.h:37,
                 from ../systemd-238/src/core/unit.h:34,
                 from ../systemd-238/src/core/dbus-timer.h:25,
                 from ../systemd-238/src/core/timer.c:26:
[...]/sys/mount.h:57:2: error: expected identifier before numeric constant