### PR TITLE
fixup! Disable timesyncd

### DIFF
--- a/debian/systemd.postinst
+++ b/debian/systemd.postinst
@@ -85,9 +85,6 @@ if dpkg --compare-versions "$2" lt-nl "239-6"; then
     done
 fi
 
-adduser --quiet --system --group --no-create-home --home /run/systemd \
-    --gecos "systemd Time Synchronization" systemd-timesync
-
 # Initial update of the Message Catalogs database
 _update_catalog
 


### PR DESCRIPTION
Do not create a systemd-timesync user. During the last rebase I let this
slip through the cracks. Leaving as a fixup so we remember to do it as
part of the commit which disables timesyncd on the next rebase.

https://phabricator.endlessm.com/T23373