### PR TITLE
Do not create kvm group

### DIFF
--- a/debian/udev.postinst
+++ b/debian/udev.postinst
@@ -99,9 +99,6 @@ case "$1" in
     # Add new system group used by udev rules
     addgroup --quiet --system input
 
-    # Make /dev/kvm accessible to kvm group
-    addgroup --quiet --system kvm
-
     if [ -z "$2" ]; then # first install
       if ! chrooted && ! in_debootstrap; then
 	enable_udev


### PR DESCRIPTION
We set /dev/kvm access mode to 0666, so we don't need a kvm user or
group.

https://phabricator.endlessm.com/T23373