### PR TITLE
Revert "[DEB] Bring tmpfiles.d/tmp.conf in line with Debian defaults"

### DIFF
--- a/tmpfiles.d/tmp.conf
+++ b/tmpfiles.d/tmp.conf
@@ -8,8 +8,8 @@
 # See tmpfiles.d(5) for details
 
 # Clear tmp directories separately, to make them easier to override
-D /tmp 1777 root root -
-#q /var/tmp 1777 root root 30d
+q /tmp 1777 root root 10d
+q /var/tmp 1777 root root 30d
 
 # Exclude namespace mountpoints created with PrivateTmp=yes
 x /tmp/systemd-private-%b-*


### PR DESCRIPTION
This reverts commit 8555ddc2f411095b8d9c2022030f6779c6261e49.

Debian's policy is to never clean-up /var/tmp to keep consistency with
the SysV init system. Flatpak creates temporary files in /var/tmp during
app updates but does not remove them on error, to avoid re-downloading
them on a future update attempt, and expects these files to be
automatically cleaned-up by the system eventually, according to the
site's policy. With this policy in place these files are never removed,
wasting the user's storage space.

Revert this commit back to upstream's default policy of cleaning up /tmp
every 10 days and /var/tmp every 30 days.

https://phabricator.endlessm.com/T23762