### PR TITLE
tmpfiles.d: Clean-up /tmp and /var/tmp more often

### DIFF
--- a/tmpfiles.d/tmp.conf
+++ b/tmpfiles.d/tmp.conf
@@ -8,8 +8,8 @@
 # See tmpfiles.d(5) for details
 
 # Clear tmp directories separately, to make them easier to override
-q /tmp 1777 root root 10d
-q /var/tmp 1777 root root 30d
+q /tmp 1777 root root 0
+q /var/tmp 1777 root root 7d
 
 # Exclude namespace mountpoints created with PrivateTmp=yes
 x /tmp/systemd-private-%b-*

--- a/tmpfiles.d/tmp.conf
+++ b/tmpfiles.d/tmp.conf
@@ -8,8 +8,8 @@
 # See tmpfiles.d(5) for details
 
 # Clear tmp directories separately, to make them easier to override
-D /tmp 1777 root root -
-#q /var/tmp 1777 root root 30d
+q /tmp 1777 root root 10d
+q /var/tmp 1777 root root 30d
 
 # Exclude namespace mountpoints created with PrivateTmp=yes
 x /tmp/systemd-private-%b-*


### PR DESCRIPTION
Flatpak uses /var/tmp for temporary files that it expects to be
cleaned-up automatically by the system, according to the site's policy.

Let's have a more aggresive policy where all files in /tmp and files
older than 7 days in /var/tmp are removed when systemd-tmpfiles performs
a cleanup, which is on boot, 15 minutes after boot, and every 1 day
afterwards (until reboot).

As a side note, the Filesystem Hierarchy Standard states that files in
/var/tmp should be preserved between system reboots, and recommends it
is deleted less frequently than files in /tmp [1]. It also states that
"programs must not assume that any files or directories in /tmp are
preserved between invocations of the program" [2].

[1] http://www.pathname.com/fhs/pub/fhs-2.3.html#VARTMPTEMPORARYFILESPRESERVEDBETWEE
[2] http://www.pathname.com/fhs/pub/fhs-2.3.html#TMPTEMPORARYFILES

https://phabricator.endlessm.com/T23762