### PR TITLE
tmpfiles: Order tmpfiles-setup after journald

### DIFF
--- a/units/systemd-tmpfiles-setup.service.in
+++ b/units/systemd-tmpfiles-setup.service.in
@@ -13,7 +13,7 @@ Documentation=man:tmpfiles.d(5) man:systemd-tmpfiles(8)
 DefaultDependencies=no
 Conflicts=shutdown.target
 After=systemd-readahead-collect.service systemd-readahead-replay.service
-After=local-fs.target systemd-sysusers.service
+After=local-fs.target systemd-sysusers.service systemd-journald.service
 Before=sysinit.target shutdown.target
 RefuseManualStop=yes
 


### PR DESCRIPTION
systemd-tmpfiles-setup.service needs to be ordered after
systemd-journald.service, so entries in /run/log/journal are already
created when systemd-tmpfiles tries to adjust its permissions.

This is specially problematic for setups using a volatile journal where
the initrd does not ship a machine-id (i.e. OSTree-based systems), where
logs from the initrd will be inaccessible for users in the
systemd-journal group. It also has a side effect of `journalctl --user`
failing with "No journal files were opened due to insufficient
permissions".

https://phabricator.endlessm.com/T23634