### PR TITLE
hwdb: Map 0x35 to screenlock for Asus WMI hotkeys

### DIFF
--- a/hwdb/60-keyboard.hwdb
+++ b/hwdb/60-keyboard.hwdb
@@ -208,6 +208,9 @@ evdev:atkbd:dmi:bvn*:bvr*:bd*:svnASUS:pn*
 evdev:name:Asus WMI hotkeys:dmi:bvn*:bvr*:bd*:svnASUS*:pn*:pvr*
 evdev:name:Eee PC WMI hotkeys:dmi:bvn*:bvr*:bd*:svnASUS*:pn*:pvr*
 evdev:name:Asus Laptop extra buttons:dmi:bvn*:bvr*:bd*:svnASUS*:pn*:pvr*
+evdev:name:Asus Keyboard:dmi:bvn*:bvr*:bd*:svnASUS*:pn*:pvr*
+evdev:name:ASUS Touchpad and G-sensor Custom Media Keys:dmi:bvn*:bvr*:bd*:svnASUS*:pn*:pvr*
+ KEYBOARD_KEY_35=screenlock                             # Lock the screen
  KEYBOARD_KEY_6b=f21                                    # Touchpad Toggle
 
 ###########################################################


### PR DESCRIPTION
This is mapped to KEY_DISPLAY_OFF in the kernel, but this key code is
not mapped to any XF86 media key and nothing in userspace handles it.
Let's map it to screenlock instead.

https://phabricator.endlessm.com/T20914