### PR TITLE
hwdb: Fix orientation sensor position for Acer AIO Veriton Z4660G

### DIFF
--- a/hwdb/60-sensor.hwdb
+++ b/hwdb/60-sensor.hwdb
@@ -58,7 +58,7 @@ sensor:modalias:acpi:BMA250E*:dmi:*:svnAcer:pnIconiaW1-810:*
  ACCEL_MOUNT_MATRIX=1, 0, 0; 0, -1, 0; 0, 0, 1
 
 sensor:modalias:acpi:SMO8840*:dmi:*:svnAcer:pnVeritonZ4660G:*
- ACCEL_MOUNT_MATRIX=-1, 0, 1; 0, -1, 1; 0, 0, 1
+ ACCEL_MOUNT_MATRIX=1, 0, 0; 0, -1, 0; 0, 0, 1
 
 #########################################
 # Archos


### PR DESCRIPTION
Fix the incorrect ACCEL_MOUNT_MATRIX for Acer AIO Veriton Z4660G,
which show wrong orientation in 90 degree rotation in early commit.

https://phabricator.endlessm.com/T23894