### PR TITLE
hwdb: apply same accel mount setting for more Acer AIO Veriton series

### DIFF
--- a/hwdb/60-sensor.hwdb
+++ b/hwdb/60-sensor.hwdb
@@ -58,6 +58,9 @@ sensor:modalias:acpi:BMA250E*:dmi:*:svnAcer:pnIconiaW1-810:*
  ACCEL_MOUNT_MATRIX=1, 0, 0; 0, -1, 0; 0, 0, 1
 
 sensor:modalias:acpi:SMO8840*:dmi:*:svnAcer:pnVeritonZ4660G:*
+sensor:modalias:acpi:SMO8840*:dmi:*:svnAcer:pnVeritonZ4860G:*
+sensor:modalias:acpi:SMO8840*:dmi:*:svnAcer:pnVeritonZ6860G:*
+sensor:modalias:acpi:SMO8840*:dmi:*:svnAcer:pnVeritonA890:*
  ACCEL_MOUNT_MATRIX=1, 0, 0; 0, -1, 0; 0, 0, 1
 
 #########################################


### PR DESCRIPTION
Acer Veriton Z4860G, Z6860G, A890 with the same STM accelerometer
suffer the same problem with Z4660G. Apply the same mount matrix
for them.

https://phabricator.endlessm.com/T24115