### PR TITLE
Revert "hwdb: Map scan code 0x35 to screenlock on Asus machines"

### DIFF
--- a/hwdb/60-keyboard.hwdb
+++ b/hwdb/60-keyboard.hwdb
@@ -208,9 +208,6 @@ evdev:atkbd:dmi:bvn*:bvr*:bd*:svnASUS:pn*
 evdev:name:Asus WMI hotkeys:dmi:bvn*:bvr*:bd*:svnASUS*:pn*:pvr*
 evdev:name:Eee PC WMI hotkeys:dmi:bvn*:bvr*:bd*:svnASUS*:pn*:pvr*
 evdev:name:Asus Laptop extra buttons:dmi:bvn*:bvr*:bd*:svnASUS*:pn*:pvr*
-evdev:name:Asus Keyboard:dmi:bvn*:bvr*:bd*:svnASUS*:pn*:pvr*
-evdev:name:ASUS Touchpad and G-sensor Custom Media Keys:dmi:bvn*:bvr*:bd*:svnASUS*:pn*:pvr*
- KEYBOARD_KEY_35=screenlock                             # Lock the screen
  KEYBOARD_KEY_6b=f21                                    # Touchpad Toggle
 
 ###########################################################


### PR DESCRIPTION
This reverts commit cc13eca21baf60224d1930201ebf992a07f0ff91.

We are now mapping 0x35 to KEY_SCREENLOCK in the kernel.

https://phabricator.endlessm.com/T24298