### PR TITLE
pam.d/systemd-user: add pam_keyinit to link session and user keyrings

### DIFF
--- a/debian/extra/pam.d/systemd-user
+++ b/debian/extra/pam.d/systemd-user
@@ -8,5 +8,6 @@ session  required pam_selinux.so close
 session  required pam_selinux.so nottys open
 session  required pam_loginuid.so
 session  required pam_limits.so
+session optional pam_keyinit.so force revoke
 @include common-session-noninteractive
 session optional pam_systemd.so


### PR DESCRIPTION
Apply a version of the change in 
https://github.com/systemd/systemd/commit/ab79099d so that the user
keyring is available in systemd-user sessions, which allows keys to be
configured for accessing encrypted filesystems. See
https://github.com/google/fscrypt/issues/100 and
https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1754270 for more
details.

https://phabricator.endlessm.com/T27032