### PR TITLE
fsck: Do not fail when fsck returns an error

### DIFF
--- a/src/fsck/fsck.c
+++ b/src/fsck/fsck.c
@@ -433,7 +433,7 @@ static int run(int argc, char *argv[]) {
         if (exit_status & FSCK_ERROR_CORRECTED)
                 (void) touch("/run/systemd/quotacheck");
 
-        return !!(exit_status & (FSCK_SYSTEM_SHOULD_REBOOT | FSCK_ERRORS_LEFT_UNCORRECTED));
+        return EXIT_SUCCESS;
 }
 
 DEFINE_MAIN_FUNCTION_WITH_POSITIVE_FAILURE(run);


### PR DESCRIPTION
The boot process relies on systemd-fsck return value when verifing the
root filesystem in order to continue booting. Even if the root
filesystem check fails with errors that can't be automatically recovered
from, we should continue booting in read-only mode (per the filesystem
mount options), to give the user the opportunity to backup their data
before an manual recovery can be performed.

https://phabricator.endlessm.com/T27126