### PR TITLE
PAYG: Ignore efi in dir busy check for gpt-auto-generator

### DIFF
--- a/src/basic/stat-util.h
+++ b/src/basic/stat-util.h
@@ -20,6 +20,11 @@ static inline int dir_is_empty(const char *path) {
         return dir_is_empty_at(AT_FDCWD, path);
 }
 
+int dir_is_empty_except_efi_at(int dir_fd, const char *path);
+static inline int dir_is_empty_except_efi(const char *path) {
+        return dir_is_empty_except_efi_at(AT_FDCWD, path);
+}
+
 static inline int dir_is_populated(const char *path) {
         int r;
         r = dir_is_empty(path);

--- a/src/gpt-auto-generator/gpt-auto-generator.c
+++ b/src/gpt-auto-generator/gpt-auto-generator.c
@@ -243,7 +243,7 @@ static int path_is_busy(const char *where) {
                 return log_warning_errno(r, "Cannot check if \"%s\" is a mount point: %m", where);
 
         /* not a mountpoint but it contains files */
-        r = dir_is_empty(where);
+        r = dir_is_empty_except_efi(where);
         if (r < 0)
                 return log_warning_errno(r, "Cannot check if \"%s\" is empty: %m", where);
         if (r > 0)


### PR DESCRIPTION
We want /boot to be the ESP, but it's not happening because
our /boot (from ostree deployment) contains an efi dir.

If we make an exception for the efi dir systemd will mount the
ESP over the otherwise empty /boot dir.

https://phabricator.endlessm.com/T27041