### PR TITLE
Ensure only systemd or systemd-signed can be installed

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -75,6 +75,7 @@ Depends: ${shlibs:Depends},
          adduser,
 Conflicts: consolekit,
            libpam-ck-connector,
+           systemd-signed,
 Breaks: apparmor (<< 2.9.2-1),
         systemd-shim (<< 10-4~),
         ifupdown (<< 0.8.5~),
@@ -83,6 +84,7 @@ Breaks: apparmor (<< 2.9.2-1),
         python-dbusmock (<< 0.18),
         python3-dbusmock (<< 0.18),
 Replaces: udev (<< 228-5),
+          systemd-signed,
 Description: system and service manager
  systemd is a system and service manager for Linux. It provides aggressive
  parallelization capabilities, uses socket and D-Bus activation for starting


### PR DESCRIPTION
For PAYG, the systemd-boot EFI loader needs to be signed, and this will
be part of a systemd-signed package. Ensure that only systemd or
systemd-signed can be installed by adding Conflicts and Replaces on that
package. The secure boot signer will swap these to systemd when creating
the systemd-signed package.

https://phabricator.endlessm.com/T27442