### PR TITLE
hwdb: Mark lis3lv02d sensors in HP laptops as being in the base

### DIFF
--- a/hwdb/60-sensor.hwdb
+++ b/hwdb/60-sensor.hwdb
@@ -57,6 +57,12 @@
 # automatically flip their output for an upside-down display when the device
 # is held upright.
 #
+#    ACCEL_LOCATION=<location>
+#
+# where <location> is the location of the sensor. This value could be 'base'
+# or 'display'. The default, when unset, is equivalent to:
+#    ACCEL_LOCATION=display
+#
 # Sort by brand, model
 
 #########################################

--- a/hwdb/60-sensor.hwdb
+++ b/hwdb/60-sensor.hwdb
@@ -252,12 +252,10 @@ sensor:modalias:acpi:KIOX000A*:dmi:bvnINSYDECorp.:bvrBYT70A.YNCHENG.WIN.007:*:sv
 # HP
 #########################################
 
-# Laptops using the lis3lv02d device should have a first quirk applied
-# to them in the drivers/platform/x86/hp_accel.c in the kernel. The
-# quirk from "can play neverball" to "matches Windows 8 orientation"
-# is then applied below.
+# Most HP Laptop using the lis3lv02d device have it in the base,
+# mark these sensors as such.
 sensor:modalias:platform:lis3lv02d:dmi:*svn*Hewlett-Packard*:*
-  ACCEL_MOUNT_MATRIX=1, 0, 0; 0, 0, -1; 0, 1, 0
+ ACCEL_LOCATION=base
 
 sensor:modalias:acpi:SMO8500*:dmi:*:svnHewlett-Packard:pnHPStream7Tablet:*
 sensor:modalias:acpi:SMO8500*:dmi:*:svnHewlett-Packard:pnHPStream8Tablet:*

--- a/hwdb/parse_hwdb.py
+++ b/hwdb/parse_hwdb.py
@@ -126,7 +126,7 @@ def property_grammar():
              ('KEYBOARD_LED_NUMLOCK', Literal('0')),
              ('KEYBOARD_LED_CAPSLOCK', Literal('0')),
              ('ACCEL_MOUNT_MATRIX', mount_matrix),
-             ('ACCEL_LOCATION', STRING),
+             ('ACCEL_LOCATION', Or(('display', 'base'))),
             )
     fixed_props = [Literal(name)('NAME') - Suppress('=') - val('VALUE')
                    for name, val in props]
@@ -178,10 +178,6 @@ def check_one_default(prop, settings):
     if len(defaults) > 1:
         error('More than one star entry: {!r}', prop)
 
-def check_one_accel_location(prop, value):
-    if value not in ['base', 'display']:
-        error('Wrong accel location: {!r}', prop)
-
 def check_one_mount_matrix(prop, value):
     numbers = [s for s in value if s not in {';', ','}]
     if len(numbers) != 9:
@@ -224,8 +220,6 @@ def check_properties(groups):
                 check_one_default(prop, parsed.VALUE.SETTINGS)
             elif parsed.NAME == 'ACCEL_MOUNT_MATRIX':
                 check_one_mount_matrix(prop, parsed.VALUE)
-            elif parsed.NAME == 'ACCEL_LOCATION':
-                check_one_accel_location(prop, parsed.VALUE)
             elif parsed.NAME.startswith('KEYBOARD_KEY_'):
                 check_one_keycode(prop, parsed.VALUE)
 

--- a/hwdb/parse_hwdb.py
+++ b/hwdb/parse_hwdb.py
@@ -126,6 +126,7 @@ def property_grammar():
              ('KEYBOARD_LED_NUMLOCK', Literal('0')),
              ('KEYBOARD_LED_CAPSLOCK', Literal('0')),
              ('ACCEL_MOUNT_MATRIX', mount_matrix),
+             ('ACCEL_LOCATION', STRING),
             )
     fixed_props = [Literal(name)('NAME') - Suppress('=') - val('VALUE')
                    for name, val in props]
@@ -177,6 +178,10 @@ def check_one_default(prop, settings):
     if len(defaults) > 1:
         error('More than one star entry: {!r}', prop)
 
+def check_one_accel_location(prop, value):
+    if value not in ['base', 'display']:
+        error('Wrong accel location: {!r}', prop)
+
 def check_one_mount_matrix(prop, value):
     numbers = [s for s in value if s not in {';', ','}]
     if len(numbers) != 9:
@@ -219,6 +224,8 @@ def check_properties(groups):
                 check_one_default(prop, parsed.VALUE.SETTINGS)
             elif parsed.NAME == 'ACCEL_MOUNT_MATRIX':
                 check_one_mount_matrix(prop, parsed.VALUE)
+            elif parsed.NAME == 'ACCEL_LOCATION':
+                check_one_accel_location(prop, parsed.VALUE)
             elif parsed.NAME.startswith('KEYBOARD_KEY_'):
                 check_one_keycode(prop, parsed.VALUE)
 


### PR DESCRIPTION
The lis3lv02d sensor used in many HP laptops is (almost) always intented
primarily for freefall detection / HDD protection and (almost) always
is located in the base of a classic clamshell laptop

Before we had the ACCEL_LOCATION udev property the issues this caused
with screen-rotation were fixed by applying a mount-matrix which
translates base-coordinates to display-coordinates assuming the display
is at an angle of exact 90 degrees to the base (swap Y and Z axis).

The comment calls this translate "from "can play neverball" to
"matches Windows 8 orientation"" but what it really does is translate
base accel-axis to display accel-axis. Thus allows rotating the screen
if you put the laptop on its side, but no-one normally does that with
a 2Kg clamshell laptop.

The obviously correct thing to do on classic clamshell laptops (not 2-in-1s)
is to disable automatic screen rotation. This commit marks the accelerometer
in these laptops as being part of the base, which will make iio-sensor-proxy
disable automatic screen rotation.

This commit also removes the orientation-matrix since the unmodified coordinates
coming from the sensor are oriented correctly for a sensor in the base.

Also see the "Bad accelerometer values cause incorrect screen rotation"
systemd-devel mail-thread from September 2019.

https://phabricator.endlessm.com/T27719