### PR TITLE
sd-boot: Work around odd behaviour in some firmware

### DIFF
--- a/src/boot/efi/boot.c
+++ b/src/boot/efi/boot.c
@@ -16,6 +16,11 @@
 #define EFI_OS_INDICATIONS_BOOT_TO_FW_UI 0x0000000000000001ULL
 #endif
 
+/* Some BIOSes scan the boot loader binary for the string "Microsoft" and
+ * deliver broken ACPI tables if it's not present.
+ */
+const char bios_confuser[] = "Microsoft";
+
 /* magic string to find in the binary image */
 static const char __attribute__((used)) magic[] = "#### LoaderInfo: systemd-boot " GIT_VERSION " ####";
 

--- a/src/boot/efi/meson.build
+++ b/src/boot/efi/meson.build
@@ -200,6 +200,17 @@ if have_gnu_efi
                         install : true,
                         install_dir : bootlibdir)
 
+                # Check to make sure nothing has elided the "Microsoft"
+                # string we injected into systemd-boot
+                if want_tests != 'false'
+                        if tuple[0] == 'systemd_boot.so'
+                                ms_test_sh = find_program('ms_test.sh')
+                                test('Microsoft string present',
+                                     ms_test_sh,
+                                     args : [stub])
+                        endif
+                endif
+
                 set_variable(tuple[0].underscorify(), so)
                 set_variable(tuple[0].underscorify() + '_stub', stub)
         endforeach

--- a/src/boot/efi/ms_test.sh
+++ b/src/boot/efi/ms_test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo Looking for string \'Microsoft\' in "$1"
+grep Microsoft "$1"


### PR DESCRIPTION
We've encountered firmware that searches the boot loader for the string
"Microsoft" and uses that to determine which ACPI table to deliver to
the kernel.

Make sure that string is present so these computers do the right thing.

https://phabricator.endlessm.com/T27753