### PR TITLE
logind: consider "greeter" sessions suitable as "display" sessions of a user

### DIFF
--- a/src/login/logind-user.c
+++ b/src/login/logind-user.c
@@ -661,7 +661,7 @@ static bool elect_display_filter(Session *s) {
         /* Return true if the session is a candidate for the user’s ‘primary session’ or ‘display’. */
         assert(s);
 
-        return s->class == SESSION_USER && s->started && !s->stopping;
+        return IN_SET(s->class, SESSION_USER, SESSION_GREETER) && s->started && !s->stopping;
 }
 
 static int elect_display_compare(Session *s1, Session *s2) {


### PR DESCRIPTION
Interestingly, elect_display_compare() already ordered "user" sessions
before "greeter" sessions, though nothing other than "user" sessions
where ever considered anyway.

Fixes: #12399
(cherry picked from commit a2dcb1d78737d3daa301ee63fbdd02837acb71a8)
Signed-off-by: Robert McQueen <rob@endlessm.com>

https://phabricator.endlessm.com/T28186