### PR TITLE
[Endless] Drop 'render' group

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -796,9 +796,6 @@ conf.set10('ENABLE_WHEEL_GROUP', get_option('wheel-group'))
 dev_kvm_mode = get_option('dev-kvm-mode')
 substs.set('DEV_KVM_MODE', dev_kvm_mode)
 conf.set10('DEV_KVM_UACCESS', dev_kvm_mode != '0666')
-group_render_mode = get_option('group-render-mode')
-substs.set('GROUP_RENDER_MODE', group_render_mode)
-conf.set10('GROUP_RENDER_UACCESS', group_render_mode != '0666')
 
 kill_user_processes = get_option('default-kill-user-processes')
 conf.set10('KILL_USER_PROCESSES', kill_user_processes)
@@ -3180,7 +3177,6 @@ status = [
         'minimum container UID base:        @0@'.format(container_uid_base_min),
         'maximum container UID base:        @0@'.format(container_uid_base_max),
         '/dev/kvm access mode:              @0@'.format(get_option('dev-kvm-mode')),
-        'render group access mode:          @0@'.format(get_option('group-render-mode')),
         'certificate root directory:        @0@'.format(get_option('certificate-root')),
         'support URL:                       @0@'.format(support_url),
         'nobody user name:                  @0@'.format(nobody_user),

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -203,8 +203,6 @@ option('nobody-group', type : 'string',
        value : 'nobody')
 option('dev-kvm-mode', type : 'string', value : '0666',
        description : '/dev/kvm access mode')
-option('group-render-mode', type : 'string', value : '0666',
-       description : 'Access mode for devices owned by render group (e.g. /dev/dri/renderD*, /dev/kfd).')
 option('default-kill-user-processes', type : 'boolean',
        description : 'the default value for KillUserProcesses= setting')
 option('gshadow', type : 'boolean',

--- a/rules.d/50-udev-default.rules.in
+++ b/rules.d/50-udev-default.rules.in
@@ -31,13 +31,10 @@ SUBSYSTEM=="input", KERNEL=="js[0-9]*", MODE="0664"
 
 SUBSYSTEM=="video4linux", GROUP="video"
 SUBSYSTEM=="graphics", GROUP="video"
-SUBSYSTEM=="drm", KERNEL!="renderD*", GROUP="video"
+SUBSYSTEM=="drm", GROUP="video"
 SUBSYSTEM=="dvb", GROUP="video"
 SUBSYSTEM=="media", GROUP="video"
 SUBSYSTEM=="cec", GROUP="video"
-
-SUBSYSTEM=="drm", KERNEL=="renderD*", GROUP="render", MODE="@GROUP_RENDER_MODE@"
-SUBSYSTEM=="kfd", GROUP="render", MODE="@GROUP_RENDER_MODE@"
 
 # When using static_node= with non-default permissions, also update
 # tmpfiles.d/static-nodes-permissions.conf.in to keep permissions synchronized.

--- a/src/login/70-uaccess.rules.m4
+++ b/src/login/70-uaccess.rules.m4
@@ -45,11 +45,7 @@ SUBSYSTEM=="firewire", ATTR{units}=="*0x00a02d:0x010001*", TAG+="uaccess"
 SUBSYSTEM=="firewire", ATTR{units}=="*0x00a02d:0x014001*", TAG+="uaccess"
 
 # DRI video devices
-SUBSYSTEM=="drm", KERNEL=="card*", TAG+="uaccess"
-m4_ifdef(`GROUP_RENDER_UACCESS',``
-# DRI render nodes
-SUBSYSTEM=="drm", KERNEL=="renderD*", TAG+="uaccess"''
-)m4_dnl
+SUBSYSTEM=="drm", KERNEL=="card*|renderD*", TAG+="uaccess"
 m4_ifdef(`DEV_KVM_UACCESS',``
 # KVM
 SUBSYSTEM=="misc", KERNEL=="kvm", TAG+="uaccess"''

--- a/test/fuzz/fuzz-udev-rules/50-udev-default.rules
+++ b/test/fuzz/fuzz-udev-rules/50-udev-default.rules
@@ -31,13 +31,10 @@ SUBSYSTEM=="input", KERNEL=="js[0-9]*", MODE="0664"
 
 SUBSYSTEM=="video4linux", GROUP="video"
 SUBSYSTEM=="graphics", GROUP="video"
-SUBSYSTEM=="drm", KERNEL!="renderD*", GROUP="video"
+SUBSYSTEM=="drm", GROUP="video"
 SUBSYSTEM=="dvb", GROUP="video"
 SUBSYSTEM=="media", GROUP="video"
 SUBSYSTEM=="cec", GROUP="video"
-
-SUBSYSTEM=="drm", KERNEL=="renderD*", GROUP="render", MODE="0666"
-SUBSYSTEM=="kfd", GROUP="render", MODE="0666"
 
 SUBSYSTEM=="sound", GROUP="audio", \
   OPTIONS+="static_node=snd/seq", OPTIONS+="static_node=snd/timer"


### PR DESCRIPTION
udev upstream is not setting the group of /dev/dri/renderD* nodes with
group render. We don't need this group on Endless OS, so lets revert
this change for now.

This reverts 3 commits, with manual intervention required because some
files have been moved around:

1. 055a083a47 "Re-add uaccess tag for /dev/dri/renderD*"
2. f301622d84 "udev-rules: Add rule for /dev/kfd"
3. 4e15a7343c "udev-rules: Permission changes for /dev/dri/renderD*"

https://phabricator.endlessm.com/T29279