### PR TITLE
Do not create 'render' group

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -80,8 +80,7 @@ CONFFLAGS = \
 	-Dnobody-user=nobody \
 	-Dnobody-group=nogroup \
 	-Dbump-proc-sys-fs-nr-open=false \
-	-Ddev-kvm-mode=0666 \
-	-Dgroup-render-mode=0660
+	-Ddev-kvm-mode=0666
 
 # resolved's DNSSEC support is still not mature enough, don't enable it by
 # default on stable Debian or any Ubuntu releases

--- a/debian/udev.postinst
+++ b/debian/udev.postinst
@@ -60,9 +60,6 @@ case "$1" in
     # Add new system group used by udev rules
     addgroup --quiet --system input
 
-    # Make /dev/dri/renderD* accessible to render group
-    addgroup --quiet --system render
-
     if [ -z "$2" ]; then # first install
       if ! chrooted && ! in_debootstrap; then
 	enable_udev


### PR DESCRIPTION
We rely on render nodes being tagged with uaccess, so we don't need to
add a special group here. Also drop passing -Dgroup-render-mode=0660
during build since we dropped that option from the code branch for the
same reason.

https://phabricator.endlessm.com/T29279