### PR TITLE
hwdb: Fix touchpad toggle on WeiHeng P325J

### DIFF
--- a/hwdb.d/60-keyboard.hwdb
+++ b/hwdb.d/60-keyboard.hwdb
@@ -1572,6 +1572,14 @@ evdev:name:SIPODEV USB Composite Device:dmi:bvn*:bvr*:bd*:svnVIOS:pnLTH17:pvr*
  KEYBOARD_KEY_70073=f21                                 # Touchpad toggle
 
 ###########################################################
+# WeiHeng
+###########################################################
+
+# P325J
+evdev:atkbd:dmi:bvn*:bvr*:bd*:svnINET:pnP325J:pvr*
+ KEYBOARD_KEY_76=f21                                    # Touchpad toggle
+
+###########################################################
 # Zepto
 ###########################################################
 


### PR DESCRIPTION
On the WeiHeng P325J laptop, Fn+F2 sends LeftWindow (0xe0 0x5b) +
LeftCtrl (0x1d) + F24 (0x76). Add a quirk to remap the 0x76 to F21 which
toggles the touchpad. The Ctrl + Win part is handled in userspace, e.g
by gnome-settings-daemon here:
https://gitlab.gnome.org/GNOME/gnome-settings-daemon/commit/f545950fe

This is analogous to what was done for the T-bao hardware here:
https://github.com/systemd/systemd/commit/d4a5df521d

(cherry picked from commit 68697cdd1274fe64ec57ac3a01f645ee821d6238)