### PR TITLE
sleep-products: Disable suspend on the Mission One

### DIFF
--- a/src/shared/sleep-products.conf
+++ b/src/shared/sleep-products.conf
@@ -32,3 +32,6 @@
 #  BlackListProducts=20AQ0069UK 3249CTO
 #
 #  Note: All the sections and variables are optional
+
+[CanSuspend]
+BlackListProducts="Mission one" GB-BXBT-2807


### PR DESCRIPTION
We detected a regression here where USB input devices do not work after
resuming from suspend. Let's disable suspend while we investigate a more
permanent solution, and on the stable branch (currently eos3.7) as well.

The Mission One is based on the Gigabyte Brix GB-BXBT-2807, so we are
disabling both product names here.

https://phabricator.endlessm.com/T29497