### PR TITLE
[Endless] gpt-auto-generator: Allow non-root to read the ESP in /boot

### DIFF
--- a/src/gpt-auto-generator/gpt-auto-generator.c
+++ b/src/gpt-auto-generator/gpt-auto-generator.c
@@ -487,7 +487,7 @@ static int add_esp(DissectedPartition *p, bool has_xbootldr) {
                              esp_path,
                              p->fstype,
                              true,
-                             "umask=0077",
+                             "umask=0022",
                              "EFI System Partition Automount",
                              120 * USEC_PER_SEC);
 }


### PR DESCRIPTION
On PAYG images we mount the ESP to /boot and install the boot loader
configuration and entries there, as this is a requirement of
sysytemd-boot. The GPT auto generator finds the ESP and generates an
automount unit for it at /boot in a way that makes it only accessible
and readable by root. OSTree needs to read the contents of
/boot/loader/entries for non-root `ostree admin status`, and probably
other similar actions.

This commit changes the umask used in boot.mount to allow for group and
others to read files and access directories in the ESP mounted to /boot.

https://phabricator.endlessm.com/T29520