### PR TITLE
sleep-products: Disable suspend on ECS EF20EA

### DIFF
--- a/src/shared/sleep-products.conf
+++ b/src/shared/sleep-products.conf
@@ -34,4 +34,4 @@
 #  Note: All the sections and variables are optional
 
 [CanSuspend]
-BlackListProducts="Mission one" GB-BXBT-2807
+BlackListProducts="Mission one" GB-BXBT-2807 EF20EA


### PR DESCRIPTION
Resuming from suspend does not work on the ECS EF20EA using recent
master or eos3.8 ostrees, so disable suspend as a short-term fix.

https://phabricator.endlessm.com/T29890