### PR TITLE
fixup! rules: Remove references to the "kvm" group

### DIFF
--- a/rules.d/50-udev-default.rules.in
+++ b/rules.d/50-udev-default.rules.in
@@ -84,8 +84,6 @@ KERNEL=="fuse", MODE="0666", OPTIONS+="static_node=fuse"
 # The static_node is required on s390x and ppc (they are using MODULE_ALIAS)
 KERNEL=="kvm", MODE="@DEV_KVM_MODE@", OPTIONS+="static_node=kvm"
 
-KERNEL=="udmabuf", GROUP="kvm"
-
 SUBSYSTEM=="ptp", ATTR{clock_name}=="KVM virtual PTP", SYMLINK += "ptp_kvm"
 
 LABEL="default_end"


### PR DESCRIPTION
Fixup for dc223266 to remove another reference to the "kvm" group. Can be squashed on next rebase.

https://phabricator.endlessm.com/T30229