### PR TITLE
hwdb: Fix Pinebook Pro's brightness up/down and sleep keys

### DIFF
--- a/hwdb.d/60-keyboard.hwdb
+++ b/hwdb.d/60-keyboard.hwdb
@@ -1366,6 +1366,16 @@ evdev:atkbd:dmi:bvn*:bvr*:bd*:svnOQO*Inc.*:pnOQO*Model*2*:pvr*
  KEYBOARD_KEY_f3=volumeup
 
 ###########################################################
+# Pine64
+###########################################################
+
+# Pinebook Pro
+evdev:input:b0003v258Ap001E*
+ KEYBOARD_KEY_700a5=brightnessdown
+ KEYBOARD_KEY_700a6=brightnessup
+ KEYBOARD_KEY_70066=sleep
+
+###########################################################
 # Plantronics
 ###########################################################
 


### PR DESCRIPTION
Pinebook Pro's display brightness up & down keys do not work until the
keys are mapped to the corresponding codes.

Also, the sleep key is mapped to KEY_POWER code originally. This quirk
maps the sleep key to the KEY_SLEEP code.

This idea comes from the pinebookpro-post-install package [1] of Manjaro
ARM, which is the preloaded OS on Pinebook Pro.

https://phabricator.endlessm.com/T31050

[1]: https://gitlab.manjaro.org/manjaro-arm/packages/community/pinebookpro-post-install/-/commit/7ab1a134ea9d5b55d99de567d1ebee4ebd6f6640