### PR TITLE
Revert "[Endless] timedated: Control ntpd instead of systemd-timesyncd"

### DIFF
--- a/units/systemd-timedated.service.in
+++ b/units/systemd-timedated.service.in
@@ -14,7 +14,6 @@ Documentation=man:localtime(5)
 Documentation=man:org.freedesktop.timedate1(5)
 
 [Service]
-Environment=SYSTEMD_TIMEDATED_NTP_SERVICES=ntpd.service
 BusName=org.freedesktop.timedate1
 CapabilityBoundingSet=CAP_SYS_TIME
 DeviceAllow=char-rtc r


### PR DESCRIPTION
Part of moving from ntpd to systemd-timesyncd.

See: https://community.endlessos.com/t/xterm-shows-in-3-10/16322/18 for more

This reverts commit 18be2ab3dde77ec57474d3792c2038221e855b6a.