### PR TITLE
Backport periodically time saving by systemd-timesyncd

### DIFF
--- a/man/systemd-time-wait-sync.service.xml
+++ b/man/systemd-time-wait-sync.service.xml
@@ -29,15 +29,17 @@
   <refsect1>
     <title>Description</title>
 
-    <para><filename>systemd-time-wait-sync</filename> is a system service that delays the start of units that depend on
-    <filename>time-sync.target</filename> until the system time has been synchronized with an accurate time source by
+    <para><filename>systemd-time-wait-sync</filename> is a system service that delays the start of units that
+    are ordered after <filename>time-sync.target</filename> (see
+    <citerefentry><refentrytitle>systemd.special</refentrytitle><manvolnum>7</manvolnum></citerefentry> for
+    details) until the system time has been synchronized with an accurate remote reference time source by
     <filename>systemd-timesyncd.service</filename>.</para>
 
-    <para><filename>systemd-timesyncd.service</filename> notifies on successful synchronization.
-    <filename>systemd-time-wait-sync</filename> also tries to detect when the kernel marks the time as synchronized,
-    but this detection is not reliable and is intended only as a fallback for other services that can be used to
-    synchronize time (e.g., ntpd, chronyd).</para>
-
+    <para><filename>systemd-timesyncd.service</filename> notifies <filename>systemd-time-wait-sync</filename>
+    about successful synchronization.  <filename>systemd-time-wait-sync</filename> also tries to detect when
+    the kernel marks the system clock as synchronized, but this detection is not reliable and is intended
+    only as a fallback for compatibility with alternative NTP services that can be used to synchronize time
+    (e.g., ntpd, chronyd).</para>
   </refsect1>
 
   <refsect1>

--- a/man/systemd-timesyncd.service.xml
+++ b/man/systemd-timesyncd.service.xml
@@ -75,10 +75,11 @@
         <term><filename>/var/lib/systemd/timesync/clock</filename></term>
 
         <listitem>
-          <para>The modification time ("mtime") of this file indicates the timestamp of the last successful
-          synchronization (or at least the systemd build date, in case synchronization was not possible). It
-          is used to ensure that the system clock remains roughly monotonic across reboots, in case no local
-          RTC is available.</para>
+          <para>The modification time ("mtime") of this file is updated on each successful NTP synchronization
+          or after each <varname>SaveIntervalSec=</varname> time interval, as specified in
+          <citerefentry><refentrytitle>timesyncd.conf</refentrytitle><manvolnum>5</manvolnum></citerefentry>.
+          At the minimum, it will be set to the systemd build date. It is used to ensure that the system clock
+          remains roughly monotonic across reboots, in case no local RTC is available.</para>
         </listitem>
       </varlistentry>
 

--- a/man/systemd-timesyncd.service.xml
+++ b/man/systemd-timesyncd.service.xml
@@ -59,9 +59,8 @@
     after <filename>time-set.target</filename> (see
     <citerefentry><refentrytitle>systemd.special</refentrytitle><manvolnum>7</manvolnum></citerefentry> for
     details) until the local time has been updated from <filename>/var/lib/systemd/timesync/clock</filename>
-    (see below) in order to make it roughly monotonic (see above), should this be necessary — for example
-    because no RTC device is available. It does not delay other units until synchronization with an accurate
-    reference time sources has been reached. Use
+    (see below) in order to make it roughly monotonic. It does not delay other units until synchronization
+    with an accurate reference time sources has been reached. Use
     <citerefentry><refentrytitle>systemd-time-wait-sync.service</refentrytitle><manvolnum>8</manvolnum></citerefentry>
     to achieve that, which will delay start of units that are ordered after
     <filename>time-sync.target</filename> until synchronization to an accurate reference clock is

--- a/man/systemd-timesyncd.service.xml
+++ b/man/systemd-timesyncd.service.xml
@@ -29,35 +29,43 @@
   <refsect1>
     <title>Description</title>
 
-    <para><filename>systemd-timesyncd</filename> is a system service
-    that may be used to synchronize the local system clock with a
-    remote Network Time Protocol server. It also saves the local time
-    to disk every time the clock has been synchronized and uses this
-    to possibly advance the system realtime clock on subsequent
-    reboots to ensure it monotonically advances even if the system
-    lacks a battery-buffered RTC chip.</para>
+    <para><filename>systemd-timesyncd</filename> is a system service that may be used to synchronize the
+    local system clock with a remote Network Time Protocol (NTP) server. It also saves the local time to disk
+    every time the clock has been synchronized and uses this to possibly advance the system realtime clock on
+    subsequent reboots to ensure it (roughly) monotonically advances even if the system lacks a
+    battery-buffered RTC chip.</para>
 
-    <para>The <filename>systemd-timesyncd</filename> service
-    specifically implements only SNTP. This minimalistic
-    service will set the system clock for large offsets or
-    slowly adjust it for smaller deltas. More complex use
-    cases are not covered by <filename>systemd-timesyncd</filename>.</para>
+    <para>The <filename>systemd-timesyncd</filename> service implements SNTP only. This minimalistic service
+    will step the system clock for large offsets or slowly adjust it for smaller deltas. Complex use cases
+    that require full NTP support (and where SNTP is not sufficient) are not covered by
+    <filename>systemd-timesyncd</filename>.</para>
 
-    <para>The NTP servers contacted are determined from the global
-    settings in
-    <citerefentry><refentrytitle>timesyncd.conf</refentrytitle><manvolnum>5</manvolnum></citerefentry>,
-    the per-link static settings in <filename>.network</filename>
-    files, and the per-link dynamic settings received over DHCP. See
-    <citerefentry><refentrytitle>systemd.network</refentrytitle><manvolnum>5</manvolnum></citerefentry>
-    for more details.</para>
+    <para>The NTP servers contacted are determined from the global settings in
+    <citerefentry><refentrytitle>timesyncd.conf</refentrytitle><manvolnum>5</manvolnum></citerefentry>, the
+    per-link static settings in <filename>.network</filename> files, and the per-link dynamic settings
+    received over DHCP. See
+    <citerefentry><refentrytitle>systemd.network</refentrytitle><manvolnum>5</manvolnum></citerefentry> for
+    further details.</para>
 
     <para><citerefentry><refentrytitle>timedatectl</refentrytitle><manvolnum>1</manvolnum></citerefentry>'s
-    <command>set-ntp</command> command may be used to enable and
-    start, or disable and stop this service.</para>
+    <command>set-ntp</command> command may be used to enable and start, or disable and stop this
+    service.</para>
 
     <para><citerefentry><refentrytitle>timedatectl</refentrytitle><manvolnum>1</manvolnum></citerefentry>'s
     <command>timesync-status</command> or <command>show-timesync</command> command can be used to show the
     current status of this service.</para>
+
+    <para><filename>systemd-timesyncd</filename> initialization delays the start of units that are ordered
+    after <filename>time-set.target</filename> (see
+    <citerefentry><refentrytitle>systemd.special</refentrytitle><manvolnum>7</manvolnum></citerefentry> for
+    details) until the local time has been updated from <filename>/var/lib/systemd/timesync/clock</filename>
+    (see below) in order to make it roughly monotonic (see above), should this be necessary — for example
+    because no RTC device is available. It does not delay other units until synchronization with an accurate
+    reference time sources has been reached. Use
+    <citerefentry><refentrytitle>systemd-time-wait-sync.service</refentrytitle><manvolnum>8</manvolnum></citerefentry>
+    to achieve that, which will delay start of units that are ordered after
+    <filename>time-sync.target</filename> until synchronization to an accurate reference clock is
+    reached.</para>
   </refsect1>
 
   <refsect1>
@@ -68,9 +76,10 @@
         <term><filename>/var/lib/systemd/timesync/clock</filename></term>
 
         <listitem>
-          <para>The modification time of this file indicates the timestamp of the last successful
-          synchronization (or at least the systemd build date, in case synchronization was not
-          possible).</para>
+          <para>The modification time ("mtime") of this file indicates the timestamp of the last successful
+          synchronization (or at least the systemd build date, in case synchronization was not possible). It
+          is used to ensure that the system clock remains roughly monotonic across reboots, in case no local
+          RTC is available.</para>
         </listitem>
       </varlistentry>
 
@@ -80,7 +89,7 @@
         <listitem>
           <para>A file that is touched on each successful synchronization, to assist
           <filename>systemd-time-wait-sync</filename> and other applications to detecting synchronization
-          events.</para>
+          with accurate reference clocks.</para>
         </listitem>
 
       </varlistentry>
@@ -95,6 +104,7 @@
       <citerefentry><refentrytitle>systemd.network</refentrytitle><manvolnum>5</manvolnum></citerefentry>,
       <citerefentry><refentrytitle>systemd-networkd.service</refentrytitle><manvolnum>8</manvolnum></citerefentry>,
       <citerefentry><refentrytitle>systemd-time-wait-sync.service</refentrytitle><manvolnum>8</manvolnum></citerefentry>,
+      <citerefentry><refentrytitle>systemd.special</refentrytitle><manvolnum>7</manvolnum></citerefentry>,
       <citerefentry><refentrytitle>timedatectl</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
       <citerefentry><refentrytitle>localtime</refentrytitle><manvolnum>5</manvolnum></citerefentry>,
       <citerefentry project='man-pages'><refentrytitle>hwclock</refentrytitle><manvolnum>8</manvolnum></citerefentry>

--- a/man/systemd.special.xml
+++ b/man/systemd.special.xml
@@ -1018,7 +1018,16 @@
             in. systemd automatically adds dependencies of type
             <varname>After=</varname> for this target unit to all SysV
             init script service units with an LSB header referring to
-            the <literal>$time</literal> facility. </para>
+            the <literal>$time</literal> facility, and also to all timer
+            units with at least one <varname>OnCalendar=</varname>
+            directive. </para>
+
+            <para>This target might get reached before the clock is actually synchronized to an accurate reference
+            clock. To prevent that, enable
+            <citerefentry><refentrytitle>systemd-time-wait-sync.service</refentrytitle><manvolnum>8</manvolnum></citerefentry>
+            if you're using
+            <citerefentry><refentrytitle>systemd-timesyncd.service</refentrytitle><manvolnum>8</manvolnum></citerefentry>,
+            or an equivalent service for other NTP implementations.</para>
           </listitem>
         </varlistentry>
       </variablelist>

--- a/man/systemd.special.xml
+++ b/man/systemd.special.xml
@@ -998,36 +998,103 @@
         <varlistentry>
           <term><filename>time-set.target</filename></term>
           <listitem>
-            <para>Services responsible for setting the system clock from
-            a local source (such as a maintained timestamp file or
-            imprecise real-time clock) should pull in this target and
-            order themselves before it.  Services where approximate time
-            is desired should be ordered after this unit, but not pull
-            it in.  This target does not provide the accuracy guarantees
-            of <filename>time-sync.target</filename>.</para>
+            <para>Services responsible for setting the system clock (<constant>CLOCK_REALTIME</constant>)
+            from a local source (such as a maintained timestamp file or imprecise real-time clock) should
+            pull in this target and order themselves before it. Services where approximate, roughly monotonic
+            time is desired should be ordered after this unit, but not pull it in.</para>
+
+            <para>This target does not provide the accuracy guarantees of
+            <filename>time-sync.target</filename> (see below), however does not depend on remote clock
+            sources to be reachable, i.e. the target is typically not delayed by network problems and
+            similar. Use of this target is recommended for services where approximate clock accuracy and
+            rough monotonicity is desired but activation shall not be delayed for possibly unreliable network
+            communication.</para>
+
+            <para>The service manager automatically adds dependencies of type <varname>After=</varname> for
+            this target unit to all timer units with at least one <varname>OnCalendar=</varname>
+            directive.</para>
+
+            <para>The
+            <citerefentry><refentrytitle>systemd-timesyncd.service</refentrytitle><manvolnum>8</manvolnum></citerefentry>
+            service is a simple daemon that pulls in this target and orders itself before it. Besides
+            implementing the SNTP network protocol it maintains a timestamp file on disk whose modification
+            time is regularlary updated. At service start-up the local system clock is updated accordingly,
+            ensuring it increases roughly monotonically.</para>
+
+            <para>Note that ordering a unit after <filename>time-set.target</filename> only has effect if
+            there's actually a service ordered before it that delays it until the clock is adjusted for rough
+            monotonicity. Otherwise, this target might get reached before the clock is adjusted to be roughly
+            monotonic. Enable
+            <citerefentry><refentrytitle>systemd-timesyncd.service</refentrytitle><manvolnum>8</manvolnum></citerefentry>,
+            to achieve that — or an alternative NTP implementation.</para>
           </listitem>
         </varlistentry>
         <varlistentry>
           <term><filename>time-sync.target</filename></term>
           <listitem>
-            <para>Services responsible for synchronizing the system
-            clock from a remote source (such as NTP client
-            implementations) should pull in this target and order
-            themselves before it. All services where correct time is
-            essential should be ordered after this unit, but not pull it
-            in. systemd automatically adds dependencies of type
-            <varname>After=</varname> for this target unit to all SysV
-            init script service units with an LSB header referring to
-            the <literal>$time</literal> facility, and also to all timer
-            units with at least one <varname>OnCalendar=</varname>
-            directive. </para>
+            <para>Services indicating completed synchronization of the system clock
+            (<constant>CLOCK_REALTIME</constant>) to a remote source should pull in this target and order
+            themselves before it. Services where accurate time is essential should be ordered after this
+            unit, but not pull it in.</para>
 
-            <para>This target might get reached before the clock is actually synchronized to an accurate reference
-            clock. To prevent that, enable
-            <citerefentry><refentrytitle>systemd-time-wait-sync.service</refentrytitle><manvolnum>8</manvolnum></citerefentry>
-            if you're using
+            <para>The service manager automatically adds dependencies of type <varname>After=</varname> for
+            this target unit to all SysV init script service units with an LSB header referring to the
+            <literal>$time</literal> facility, as well to all timer units with at least one
+            <varname>OnCalendar=</varname> directive.</para>
+
+            <para>This target provides stricter clock accuracy guarantees than
+            <filename>time-set.target</filename> (see above), but likely relies on possibly unreliable
+            network communication and thus might introduce possibly substantial activation delays for
+            services ordered after this target. Services that require clock accuracy and where network
+            communication delays are acceptable should use this target. Services that require a less accurate
+            clock, and only approximate and roughly monotonic clock behaviour should use
+            <filename>time-set.target</filename> instead.</para>
+
+            <para>Note that ordering a unit after <filename>time-sync.target</filename> only has effect if
+            there's actually a service ordered before it that delays it until clock synchronization is
+            reached. Otherwise, this target might get reached before the clock is synchronized to any remote
+            accurate reference clock. When using
             <citerefentry><refentrytitle>systemd-timesyncd.service</refentrytitle><manvolnum>8</manvolnum></citerefentry>,
-            or an equivalent service for other NTP implementations.</para>
+            enable
+            <citerefentry><refentrytitle>systemd-time-wait-sync.service</refentrytitle><manvolnum>8</manvolnum></citerefentry>
+            to achieve that; or use an equivalent service for other NTP implementations.</para>
+
+            <table>
+              <title>Comparison</title>
+              <tgroup cols='2' align='left' colsep='1' rowsep='1'>
+                <colspec colname="time-set" />
+                <colspec colname="time-sync" />
+                <thead>
+                  <row>
+                    <entry><filename>time-set.target</filename></entry>
+                    <entry><filename>time-sync.target</filename></entry>
+                  </row>
+                </thead>
+                <tbody>
+                  <row>
+                    <entry>"quick" to reach</entry>
+                    <entry>"slow" to reach</entry>
+                  </row>
+                  <row>
+                    <entry>typically uses local clock sources, boot process not affected by availability of external resources</entry>
+                    <entry>typically uses remote clock sources, inserts dependencies on remote resources into boot process</entry>
+                  </row>
+                  <row>
+                    <entry>reliable, because local</entry>
+                    <entry>unreliable, because typically network involved</entry>
+                  </row>
+                  <row>
+                    <entry>typically guarantees an approximate and roughly monotonic clock only</entry>
+                    <entry>typically guarantees an accurate clock</entry>
+                  </row>
+                  <row>
+                    <entry>implemented by <filename>systemd-timesyncd.service</filename></entry>
+                    <entry>implemented by <filename>systemd-time-wait-sync.service</filename></entry>
+                  </row>
+                </tbody>
+              </tgroup>
+            </table>
+
           </listitem>
         </varlistentry>
       </variablelist>

--- a/man/systemd.special.xml
+++ b/man/systemd.special.xml
@@ -1018,7 +1018,7 @@
             <citerefentry><refentrytitle>systemd-timesyncd.service</refentrytitle><manvolnum>8</manvolnum></citerefentry>
             service is a simple daemon that pulls in this target and orders itself before it. Besides
             implementing the SNTP network protocol it maintains a timestamp file on disk whose modification
-            time is regularlary updated. At service start-up the local system clock is updated accordingly,
+            time is regularlary updated. At service start-up the local system clock is set from that modification time,
             ensuring it increases roughly monotonically.</para>
 
             <para>Note that ordering a unit after <filename>time-set.target</filename> only has effect if
@@ -1026,7 +1026,7 @@
             monotonicity. Otherwise, this target might get reached before the clock is adjusted to be roughly
             monotonic. Enable
             <citerefentry><refentrytitle>systemd-timesyncd.service</refentrytitle><manvolnum>8</manvolnum></citerefentry>,
-            to achieve that — or an alternative NTP implementation.</para>
+            or an alternative NTP implementation to delay the target.</para>
           </listitem>
         </varlistentry>
         <varlistentry>
@@ -1043,9 +1043,9 @@
             <varname>OnCalendar=</varname> directive.</para>
 
             <para>This target provides stricter clock accuracy guarantees than
-            <filename>time-set.target</filename> (see above), but likely relies on possibly unreliable
-            network communication and thus might introduce possibly substantial activation delays for
-            services ordered after this target. Services that require clock accuracy and where network
+            <filename>time-set.target</filename> (see above), but likely requires
+            network communication and thus introduces unpredictable delays.
+            Services that require clock accuracy and where network
             communication delays are acceptable should use this target. Services that require a less accurate
             clock, and only approximate and roughly monotonic clock behaviour should use
             <filename>time-set.target</filename> instead.</para>
@@ -1057,7 +1057,7 @@
             <citerefentry><refentrytitle>systemd-timesyncd.service</refentrytitle><manvolnum>8</manvolnum></citerefentry>,
             enable
             <citerefentry><refentrytitle>systemd-time-wait-sync.service</refentrytitle><manvolnum>8</manvolnum></citerefentry>
-            to achieve that; or use an equivalent service for other NTP implementations.</para>
+            to delay the target; or use an equivalent service for other NTP implementations.</para>
 
             <table>
               <title>Comparison</title>

--- a/man/timesyncd.conf.xml
+++ b/man/timesyncd.conf.xml
@@ -91,6 +91,12 @@
         <varname>PollIntervalMaxSec=</varname> defaults to 2048 seconds.</para></listitem>
       </varlistentry>
 
+      <varlistentry>
+        <term><varname>ConnectionRetrySec=</varname></term>
+        <listitem><para>Specifies the delaying attempts to contact servers after network is online. Takes a time value (in seconds).
+        Defaults to 30 seconds and must not be smaller than 1 seconds.</para></listitem>
+      </varlistentry>
+
     </variablelist>
   </refsect1>
 

--- a/man/timesyncd.conf.xml
+++ b/man/timesyncd.conf.xml
@@ -97,6 +97,18 @@
         Defaults to 30 seconds and must not be smaller than 1 seconds.</para></listitem>
       </varlistentry>
 
+      <varlistentry>
+        <term><varname>SaveIntervalSec=</varname></term>
+        <listitem><para>The interval at which the current time is periodically saved to disk, in the absence
+        of any recent synchronisation from an NTP server. This is especially useful for offline systems
+        with no local RTC, as it will guarantee that the system clock remains roughly monotonic across
+        reboots.</para>
+
+        <para>Takes a time interval value. The default unit is seconds, but other units may be specified, see
+        <citerefentry><refentrytitle>systemd.time</refentrytitle><manvolnum>5</manvolnum></citerefentry>.
+        Defaults to 60 seconds.</para></listitem>
+      </varlistentry>
+
     </variablelist>
   </refsect1>
 

--- a/src/basic/special.h
+++ b/src/basic/special.h
@@ -42,6 +42,7 @@
 #define SPECIAL_SWAP_TARGET "swap.target"
 #define SPECIAL_NETWORK_ONLINE_TARGET "network-online.target"
 #define SPECIAL_TIME_SYNC_TARGET "time-sync.target"       /* LSB's $time */
+#define SPECIAL_TIME_SET_TARGET "time-set.target"
 #define SPECIAL_BASIC_TARGET "basic.target"
 
 /* LSB compatibility */

--- a/src/core/timer.c
+++ b/src/core/timer.c
@@ -101,14 +101,13 @@ static int timer_add_default_dependencies(Timer *t) {
                 if (r < 0)
                         return r;
 
-                LIST_FOREACH(value, v, t->values) {
+                LIST_FOREACH(value, v, t->values)
                         if (v->base == TIMER_CALENDAR) {
                                 r = unit_add_dependency_by_name(UNIT(t), UNIT_AFTER, SPECIAL_TIME_SYNC_TARGET, true, UNIT_DEPENDENCY_DEFAULT);
                                 if (r < 0)
                                         return r;
                                 break;
                         }
-                }
         }
 
         return unit_add_two_dependencies_by_name(UNIT(t), UNIT_BEFORE, UNIT_CONFLICTS, SPECIAL_SHUTDOWN_TARGET, true, UNIT_DEPENDENCY_DEFAULT);
@@ -259,8 +258,7 @@ static void timer_dump(Unit *u, FILE *f, const char *prefix) {
                 prefix, yes_no(t->on_clock_change),
                 prefix, yes_no(t->on_timezone_change));
 
-        LIST_FOREACH(value, v, t->values) {
-
+        LIST_FOREACH(value, v, t->values)
                 if (v->base == TIMER_CALENDAR) {
                         _cleanup_free_ char *p = NULL;
 
@@ -280,7 +278,6 @@ static void timer_dump(Unit *u, FILE *f, const char *prefix) {
                                 timer_base_to_string(v->base),
                                 format_timespan(timespan1, sizeof(timespan1), v->value, 0));
                 }
-        }
 }
 
 static void timer_set_state(Timer *t, TimerState state) {
@@ -670,9 +667,7 @@ static int timer_start(Unit *u) {
                         }
 
                 } else if (errno == ENOENT)
-                        /* The timer has never run before,
-                         * make sure a stamp file exists.
-                         */
+                        /* The timer has never run before, make sure a stamp file exists. */
                         (void) touch_file(t->stamp_path, true, USEC_INFINITY, UID_INVALID, GID_INVALID, MODE_INVALID);
         }
 

--- a/src/core/timer.c
+++ b/src/core/timer.c
@@ -101,13 +101,20 @@ static int timer_add_default_dependencies(Timer *t) {
                 if (r < 0)
                         return r;
 
-                LIST_FOREACH(value, v, t->values)
-                        if (v->base == TIMER_CALENDAR) {
-                                r = unit_add_dependency_by_name(UNIT(t), UNIT_AFTER, SPECIAL_TIME_SYNC_TARGET, true, UNIT_DEPENDENCY_DEFAULT);
+                LIST_FOREACH(value, v, t->values) {
+                        const char *target;
+
+                        if (v->base != TIMER_CALENDAR)
+                                continue;
+
+                        FOREACH_STRING(target, SPECIAL_TIME_SYNC_TARGET, SPECIAL_TIME_SET_TARGET) {
+                                r = unit_add_dependency_by_name(UNIT(t), UNIT_AFTER, target, true, UNIT_DEPENDENCY_DEFAULT);
                                 if (r < 0)
                                         return r;
-                                break;
                         }
+
+                        break;
+                }
         }
 
         return unit_add_two_dependencies_by_name(UNIT(t), UNIT_BEFORE, UNIT_CONFLICTS, SPECIAL_SHUTDOWN_TARGET, true, UNIT_DEPENDENCY_DEFAULT);

--- a/src/timesync/timesyncd-bus.c
+++ b/src/timesync/timesyncd-bus.c
@@ -165,7 +165,7 @@ static const sd_bus_vtable manager_vtable[] = {
         SD_BUS_PROPERTY("FallbackNTPServers", "as", property_get_servers, offsetof(Manager, fallback_servers), SD_BUS_VTABLE_PROPERTY_CONST),
         SD_BUS_PROPERTY("ServerName", "s", property_get_current_server_name, offsetof(Manager, current_server_name), 0),
         SD_BUS_PROPERTY("ServerAddress", "(iay)", property_get_current_server_address, offsetof(Manager, current_server_address), 0),
-        SD_BUS_PROPERTY("RootDistanceMaxUSec", "t", bus_property_get_usec, offsetof(Manager, max_root_distance_usec), SD_BUS_VTABLE_PROPERTY_CONST),
+        SD_BUS_PROPERTY("RootDistanceMaxUSec", "t", bus_property_get_usec, offsetof(Manager, root_distance_max_usec), SD_BUS_VTABLE_PROPERTY_CONST),
         SD_BUS_PROPERTY("PollIntervalMinUSec", "t", bus_property_get_usec, offsetof(Manager, poll_interval_min_usec), SD_BUS_VTABLE_PROPERTY_CONST),
         SD_BUS_PROPERTY("PollIntervalMaxUSec", "t", bus_property_get_usec, offsetof(Manager, poll_interval_max_usec), SD_BUS_VTABLE_PROPERTY_CONST),
         SD_BUS_PROPERTY("PollIntervalUSec", "t", bus_property_get_usec, offsetof(Manager, poll_interval_usec), 0),

--- a/src/timesync/timesyncd-conf.c
+++ b/src/timesync/timesyncd-conf.c
@@ -124,5 +124,10 @@ int manager_parse_config_file(Manager *m) {
                 m->poll_interval_max_usec = MAX(NTP_POLL_INTERVAL_MAX_USEC, m->poll_interval_min_usec * 32);
         }
 
+        if (m->connection_retry_usec < 1 * USEC_PER_SEC) {
+                log_warning("Invalid ConnectionRetrySec=. Using default value.");
+                m->connection_retry_usec = DEFAULT_CONNECTION_RETRY_USEC;
+        }
+
         return r;
 }

--- a/src/timesync/timesyncd-gperf.gperf
+++ b/src/timesync/timesyncd-gperf.gperf
@@ -17,9 +17,10 @@ struct ConfigPerfItem;
 %struct-type
 %includes
 %%
-Time.NTP,                 config_parse_servers, SERVER_SYSTEM,   0
-Time.Servers,             config_parse_servers, SERVER_SYSTEM,   0
-Time.FallbackNTP,         config_parse_servers, SERVER_FALLBACK, 0
-Time.RootDistanceMaxSec,  config_parse_sec,     0,               offsetof(Manager, max_root_distance_usec)
-Time.PollIntervalMinSec,  config_parse_sec,     0,               offsetof(Manager, poll_interval_min_usec)
-Time.PollIntervalMaxSec,  config_parse_sec,     0,               offsetof(Manager, poll_interval_max_usec)
+Time.NTP,                            config_parse_servers, SERVER_SYSTEM,   0
+Time.Servers,                        config_parse_servers, SERVER_SYSTEM,   0
+Time.FallbackNTP,                    config_parse_servers, SERVER_FALLBACK, 0
+Time.RootDistanceMaxSec,             config_parse_sec,     0,               offsetof(Manager, max_root_distance_usec)
+Time.PollIntervalMinSec,             config_parse_sec,     0,               offsetof(Manager, poll_interval_min_usec)
+Time.PollIntervalMaxSec,             config_parse_sec,     0,               offsetof(Manager, poll_interval_max_usec)
+Time.ConnectionRetrySec,             config_parse_sec,     0,               offsetof(Manager, connection_retry_usec)

--- a/src/timesync/timesyncd-gperf.gperf
+++ b/src/timesync/timesyncd-gperf.gperf
@@ -20,7 +20,7 @@ struct ConfigPerfItem;
 Time.NTP,                            config_parse_servers, SERVER_SYSTEM,   0
 Time.Servers,                        config_parse_servers, SERVER_SYSTEM,   0
 Time.FallbackNTP,                    config_parse_servers, SERVER_FALLBACK, 0
-Time.RootDistanceMaxSec,             config_parse_sec,     0,               offsetof(Manager, max_root_distance_usec)
+Time.RootDistanceMaxSec,             config_parse_sec,     0,               offsetof(Manager, root_distance_max_usec)
 Time.PollIntervalMinSec,             config_parse_sec,     0,               offsetof(Manager, poll_interval_min_usec)
 Time.PollIntervalMaxSec,             config_parse_sec,     0,               offsetof(Manager, poll_interval_max_usec)
 Time.ConnectionRetrySec,             config_parse_sec,     0,               offsetof(Manager, connection_retry_usec)

--- a/src/timesync/timesyncd-gperf.gperf
+++ b/src/timesync/timesyncd-gperf.gperf
@@ -24,3 +24,4 @@ Time.RootDistanceMaxSec,             config_parse_sec,     0,               offs
 Time.PollIntervalMinSec,             config_parse_sec,     0,               offsetof(Manager, poll_interval_min_usec)
 Time.PollIntervalMaxSec,             config_parse_sec,     0,               offsetof(Manager, poll_interval_max_usec)
 Time.ConnectionRetrySec,             config_parse_sec,     0,               offsetof(Manager, connection_retry_usec)
+Time.SaveIntervalSec,                config_parse_sec,     0,               offsetof(Manager, save_time_interval_usec)

--- a/src/timesync/timesyncd-manager.c
+++ b/src/timesync/timesyncd-manager.c
@@ -34,7 +34,7 @@
 #define ADJ_SETOFFSET                   0x0100  /* add 'time' to current time */
 #endif
 
-/* expected accuracy of time synchronization; used to adjust the poll interval */
+/* Expected accuracy of time synchronization; used to adjust the poll interval */
 #define NTP_ACCURACY_SEC                0.2
 
 /*
@@ -45,7 +45,7 @@
 #define NTP_MAX_ADJUST                  0.4
 
 /* Default of maximum acceptable root distance in microseconds. */
-#define NTP_MAX_ROOT_DISTANCE           (5 * USEC_PER_SEC)
+#define NTP_ROOT_DISTANCE_MAX_USEC      (5 * USEC_PER_SEC)
 
 /* Maximum number of missed replies before selecting another source. */
 #define NTP_MAX_MISSED_REPLIES          2
@@ -507,7 +507,7 @@ static int manager_receive_response(sd_event_source *source, int fd, uint32_t re
         }
 
         root_distance = ntp_ts_short_to_d(&ntpmsg.root_delay) / 2 + ntp_ts_short_to_d(&ntpmsg.root_dispersion);
-        if (root_distance > (double) m->max_root_distance_usec / (double) USEC_PER_SEC) {
+        if (root_distance > (double) m->root_distance_max_usec / (double) USEC_PER_SEC) {
                 log_info("Server has too large root distance. Disconnecting.");
                 return manager_connect(m);
         }
@@ -1081,7 +1081,7 @@ int manager_new(Manager **ret) {
         if (!m)
                 return -ENOMEM;
 
-        m->max_root_distance_usec = NTP_MAX_ROOT_DISTANCE;
+        m->root_distance_max_usec = NTP_ROOT_DISTANCE_MAX_USEC;
         m->poll_interval_min_usec = NTP_POLL_INTERVAL_MIN_USEC;
         m->poll_interval_max_usec = NTP_POLL_INTERVAL_MAX_USEC;
 

--- a/src/timesync/timesyncd-manager.c
+++ b/src/timesync/timesyncd-manager.c
@@ -59,6 +59,7 @@ static int manager_arm_timer(Manager *m, usec_t next);
 static int manager_clock_watch_setup(Manager *m);
 static int manager_listen_setup(Manager *m);
 static void manager_listen_stop(Manager *m);
+static int manager_save_time_and_rearm(Manager *m);
 
 static double ntp_ts_short_to_d(const struct ntp_ts_short *ts) {
         return be16toh(ts->sec) + (be16toh(ts->frac) / 65536.0);
@@ -296,8 +297,11 @@ static int manager_adjust_clock(Manager *m, double offset, int leap_sec) {
         if (r < 0)
                 return -errno;
 
+        r = manager_save_time_and_rearm(m);
+        if (r < 0)
+                return r;
+
         /* If touch fails, there isn't much we can do. Maybe it'll work next time. */
-        (void) touch("/var/lib/systemd/timesync/clock");
         (void) touch("/run/systemd/timesync/synchronized");
 
         m->drift_freq = tmx.freq;
@@ -584,7 +588,6 @@ static int manager_receive_response(sd_event_source *source, int fd, uint32_t re
                   m->poll_interval_usec / USEC_PER_SEC);
 
         if (!spike) {
-                m->sync = true;
                 r = manager_adjust_clock(m, offset, leap_sec);
                 if (r < 0)
                         log_error_errno(r, "Failed to call clock_adjtime(): %m");
@@ -929,6 +932,8 @@ void manager_free(Manager *m) {
         sd_event_source_unref(m->network_event_source);
         sd_network_monitor_unref(m->network_monitor);
 
+        sd_event_source_unref(m->event_save_time);
+
         sd_resolve_unref(m->resolve);
         sd_event_unref(m->event);
 
@@ -1091,6 +1096,8 @@ int manager_new(Manager **ret) {
 
         m->ratelimit = (RateLimit) { RATELIMIT_INTERVAL_USEC, RATELIMIT_BURST };
 
+        m->save_time_interval_usec = DEFAULT_SAVE_TIME_INTERVAL_USEC;
+
         r = sd_event_default(&m->event);
         if (r < 0)
                 return r;
@@ -1115,6 +1122,63 @@ int manager_new(Manager **ret) {
         (void) manager_network_read_link_servers(m);
 
         *ret = TAKE_PTR(m);
+
+        return 0;
+}
+
+static int manager_save_time_handler(sd_event_source *s, uint64_t usec, void *userdata) {
+        Manager *m = userdata;
+
+        assert(m);
+
+        (void) manager_save_time_and_rearm(m);
+        return 0;
+}
+
+int manager_setup_save_time_event(Manager *m) {
+        int r;
+
+        assert(m);
+        assert(!m->event_save_time);
+
+        if (m->save_time_interval_usec == USEC_INFINITY)
+                return 0;
+
+        /* NB: we'll accumulate scheduling latencies here, but this doesn't matter */
+        r = sd_event_add_time_relative(
+                        m->event, &m->event_save_time,
+                        clock_boottime_or_monotonic(),
+                        m->save_time_interval_usec,
+                        10 * USEC_PER_SEC,
+                        manager_save_time_handler, m);
+        if (r < 0)
+                return log_error_errno(r, "Failed to add save time event: %m");
+
+        (void) sd_event_source_set_description(m->event_save_time, "save-time");
+
+        return 0;
+}
+
+static int manager_save_time_and_rearm(Manager *m) {
+        int r;
+
+        assert(m);
+
+        r = touch(CLOCK_FILE);
+        if (r < 0)
+                log_debug_errno(r, "Failed to update " CLOCK_FILE ", ignoring: %m");
+
+        m->save_on_exit = true;
+
+        if (m->save_time_interval_usec != USEC_INFINITY) {
+                r = sd_event_source_set_time_relative(m->event_save_time, m->save_time_interval_usec);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to rearm save time event: %m");
+
+                r = sd_event_source_set_enabled(m->event_save_time, SD_EVENT_ONESHOT);
+                if (r < 0)
+                        return log_error_errno(r, "Failed to enable save time event: %m");
+        }
 
         return 0;
 }

--- a/src/timesync/timesyncd-manager.h
+++ b/src/timesync/timesyncd-manager.h
@@ -27,7 +27,12 @@ typedef struct Manager Manager;
 #define NTP_RETRY_INTERVAL_MIN_USEC     (15 * USEC_PER_SEC)
 #define NTP_RETRY_INTERVAL_MAX_USEC     (6 * 60 * USEC_PER_SEC) /* 6 minutes */
 
-#define DEFAULT_CONNECTION_RETRY_USEC (30*USEC_PER_SEC)
+#define DEFAULT_CONNECTION_RETRY_USEC   (30 * USEC_PER_SEC)
+
+#define DEFAULT_SAVE_TIME_INTERVAL_USEC (60 * USEC_PER_SEC)
+
+#define STATE_DIR   "/var/lib/systemd/timesync"
+#define CLOCK_FILE  STATE_DIR "/clock"
 
 struct Manager {
         sd_bus *bus;
@@ -83,7 +88,6 @@ struct Manager {
 
         /* last change */
         bool jumped;
-        bool sync;
         int64_t drift_freq;
 
         /* watch for time changes */
@@ -100,6 +104,11 @@ struct Manager {
         struct ntp_msg ntpmsg;
         struct timespec origin_time, dest_time;
         bool spike;
+
+        /* save time event */
+        sd_event_source *event_save_time;
+        usec_t save_time_interval_usec;
+        bool save_on_exit;
 };
 
 int manager_new(Manager **ret);
@@ -113,3 +122,5 @@ void manager_flush_server_names(Manager *m, ServerType t);
 
 int manager_connect(Manager *m);
 void manager_disconnect(Manager *m);
+
+int manager_setup_save_time_event(Manager *m);

--- a/src/timesync/timesyncd-manager.h
+++ b/src/timesync/timesyncd-manager.h
@@ -79,7 +79,7 @@ struct Manager {
         } samples[8];
         unsigned samples_idx;
         double samples_jitter;
-        usec_t max_root_distance_usec;
+        usec_t root_distance_max_usec;
 
         /* last change */
         bool jumped;

--- a/src/timesync/timesyncd-manager.h
+++ b/src/timesync/timesyncd-manager.h
@@ -27,6 +27,8 @@ typedef struct Manager Manager;
 #define NTP_RETRY_INTERVAL_MIN_USEC     (15 * USEC_PER_SEC)
 #define NTP_RETRY_INTERVAL_MAX_USEC     (6 * 60 * USEC_PER_SEC) /* 6 minutes */
 
+#define DEFAULT_CONNECTION_RETRY_USEC (30*USEC_PER_SEC)
+
 struct Manager {
         sd_bus *bus;
         sd_event *event;
@@ -60,6 +62,7 @@ struct Manager {
         struct timespec trans_time_mon;
         struct timespec trans_time;
         usec_t retry_interval;
+        usec_t connection_retry_usec;
         bool pending;
 
         /* poll timer */

--- a/src/timesync/timesyncd.conf.in
+++ b/src/timesync/timesyncd.conf.in
@@ -17,3 +17,4 @@
 #RootDistanceMaxSec=5
 #PollIntervalMinSec=32
 #PollIntervalMaxSec=2048
+#SaveIntervalSec=60


### PR DESCRIPTION
Backport https://github.com/systemd/systemd/commit/33e82f3ef3 to periodically save time and keep the clock monotonic on systems without a battery-backed RTC.

This PR also brings other commits to make for clean cherry-picks. Most of those are manpage fixes, but some add a couple of small features and seem nice to have.

https://phabricator.endlessm.com/T32428