### PR TITLE
make-sysusers-basic: Exclude users installed by Endless OS

### DIFF
--- a/debian/extra/make-sysusers-basic
+++ b/debian/extra/make-sysusers-basic
@@ -14,5 +14,9 @@ done < /usr/share/base-passwd/group.master
 
 echo
 
+# Exclude the users listed in sysusers.d config files installed by other packages
+# https://phabricator.endlessm.com/T31589
+# https://phabricator.endlessm.com/T5975
+EXCLUDE_USERS=("messagebus" "kolibri" "_flatpak" "mogwai-scheduled" "systemd-journal" "systemd-timesync" "systemd-coredump")
 # treat "nobody:nogroup" specially: same ID, but different name, so prevent creating a "nobody" group
-awk -F:  '{ i = ($3 == $4 && $4 != 65534) ? $3 : $3":"$4; printf("u %-10s %-7s - %-20s %s\n", $1,i,$6,$7) }'  < /usr/share/base-passwd/passwd.master
+awk -F:  '{ i = ($3 == $4 && $4 != 65534) ? $3 : $3":"$4; printf("u %-10s %-7s - %-20s %s\n", $1,i,$6,$7) }'  < /usr/share/base-passwd/passwd.master | grep -v -E "($(IFS=\| ; echo "${EXCLUDE_USERS[*]}"))"


### PR DESCRIPTION
Some of sysusers, like messagebus, kolibri are already configured by
other packages for systemd. To avoid having the duplicated configured
sysusers in basic.conf and the confliction, this patch lists and
excludes the users.

https://phabricator.endlessm.com/T31589