### PR TITLE
Revert "[Endless] rules: Remove references to the "kvm" group"

### DIFF
--- a/rules.d/50-udev-default.rules.in
+++ b/rules.d/50-udev-default.rules.in
@@ -83,7 +83,9 @@ KERNEL=="tun", MODE="0666", OPTIONS+="static_node=net/tun"
 KERNEL=="fuse", MODE="0666", OPTIONS+="static_node=fuse"
 
 # The static_node is required on s390x and ppc (they are using MODULE_ALIAS)
-KERNEL=="kvm", MODE="@DEV_KVM_MODE@", OPTIONS+="static_node=kvm"
+KERNEL=="kvm", GROUP="kvm", MODE="@DEV_KVM_MODE@", OPTIONS+="static_node=kvm"
+
+KERNEL=="udmabuf", GROUP="kvm"
 
 SUBSYSTEM=="ptp", ATTR{clock_name}=="KVM virtual PTP", SYMLINK += "ptp_kvm"
 

--- a/test/fuzz/fuzz-udev-rules/50-udev-default.rules
+++ b/test/fuzz/fuzz-udev-rules/50-udev-default.rules
@@ -79,7 +79,7 @@ KERNEL=="tun", MODE="0666", OPTIONS+="static_node=net/tun"
 KERNEL=="fuse", MODE="0666", OPTIONS+="static_node=fuse"
 
 # The static_node is required on s390x and ppc (they are using MODULE_ALIAS)
-KERNEL=="kvm", MODE="0666", OPTIONS+="static_node=kvm"
+KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"
 
 SUBSYSTEM=="ptp", ATTR{clock_name}=="KVM virtual PTP", SYMLINK += "ptp_kvm"
 

--- a/tmpfiles.d/static-nodes-permissions.conf.in
+++ b/tmpfiles.d/static-nodes-permissions.conf.in
@@ -14,4 +14,4 @@ z /dev/snd/timer    0660 - audio -
 z /dev/loop-control 0660 - disk  -
 z /dev/net/tun      0666 - -     -
 z /dev/fuse         0666 - -     -
-z /dev/kvm          @DEV_KVM_MODE@ - -     -
+z /dev/kvm          @DEV_KVM_MODE@ - kvm -


### PR DESCRIPTION
This reverts commit d156b8640c7034483d3588f02359b89f2ad64f59.

We are going to create the kvm group, so we can drop this commit.

https://phabricator.endlessm.com/T30232