### PR TITLE
Revert "Do not create kvm group"

### DIFF
--- a/debian/udev.postinst
+++ b/debian/udev.postinst
@@ -56,6 +56,9 @@ case "$1" in
     # Add new system group used by udev rules
     addgroup --quiet --system input
 
+    # Make /dev/kvm accessible to kvm group
+    addgroup --quiet --system kvm
+
     # Make /dev/dri/renderD* accessible to render group
     addgroup --quiet --system render
 


### PR DESCRIPTION
This reverts commit 4a05639b438400e13ec6f0d7d00532745cf8988e.

We are adding the kvm group to our static list of system groups in
base-passwd, so we can drop this change.

https://phabricator.endlessm.com/T30232