### PR TITLE
Drop sysusers related files

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -231,8 +231,6 @@ override_dh_install:
 		-name systemd-udev-hwdb-update.service -o \
 		-name etc.conf \) -delete
 	rm -rf debian/install/*/usr/share/factory/
-	# replace upstream sysusers.d/basic.conf with proper users for Debian
-	debian/extra/make-sysusers-basic > debian/install/deb/usr/lib/sysusers.d/basic.conf
 	# remove resolvconf compat symlink
 	rm -f debian/install/*/sbin/resolvconf
 ifeq (, $(filter noudeb, $(DEB_BUILD_PROFILES)))

--- a/debian/systemd-journal-remote.install
+++ b/debian/systemd-journal-remote.install
@@ -12,7 +12,6 @@ etc/systemd/journal-remote.conf
 lib/systemd/systemd-journal-remote
 lib/systemd/system/systemd-journal-remote.service
 lib/systemd/system/systemd-journal-remote.socket
-usr/lib/sysusers.d/systemd-remote.conf
 usr/share/man/man5/journal-remote.conf.d.5
 usr/share/man/man5/journal-remote.conf.5
 usr/share/man/man8/systemd-journal-remote.service.8

--- a/debian/systemd.install
+++ b/debian/systemd.install
@@ -10,7 +10,6 @@ bin/systemd-machine-id-setup
 bin/systemd-tmpfiles
 bin/systemd-inhibit
 bin/systemd-escape
-bin/systemd-sysusers
 lib/modprobe.d/
 lib/systemd/
 lib/udev/rules.d/70-uaccess.rules
@@ -53,8 +52,6 @@ usr/lib/binfmt.d/
 usr/lib/environment.d/
 usr/lib/modules-load.d/
 usr/lib/sysctl.d/
-usr/lib/sysusers.d/basic.conf
-usr/lib/sysusers.d/systemd.conf
 usr/lib/systemd/
 usr/lib/tmpfiles.d/
 usr/lib/kernel


### PR DESCRIPTION
Since the sysuser.d folder does not exists when sysusers is disabled,
drop sysusers related install items.

https://phabricator.endlessm.com/T31589