### PR TITLE
Ensure only systemd-boot-efi or systemd-boot-efi-signed can be installed

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -453,7 +453,7 @@ Package: systemd-boot
 Architecture: amd64 i386 arm64 armhf
 Depends: ${shlibs:Depends},
          ${misc:Depends},
-         systemd-boot-efi (= ${binary:Version}),
+         systemd-boot-efi-signed (= ${binary:Version}) | systemd-boot-efi (= ${binary:Version}),
 Recommends: efibootmgr,
 Breaks: systemd (<< 251.2-3~)
 Replaces: systemd (<< 251.2-3~)
@@ -473,7 +473,9 @@ Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends},
 Depends: ${misc:Depends},
 Breaks: systemd (<< 251.2-3~)
-Replaces: systemd (<< 251.2-3~)
+Replaces: systemd (<< 251.2-3~),
+          systemd-boot-efi-signed
+Conflicts: systemd-boot-efi-signed
 Description: Simple UEFI boot manager - EFI binaries
  systemd-boot (short: sd-boot) is a simple UEFI boot manager. It provides a
  textual menu to select the entry to boot and an editor for the kernel command

--- a/debian/control
+++ b/debian/control
@@ -74,7 +74,7 @@ Recommends: default-dbus-system-bus | dbus-system-bus,
 Suggests: systemd-container,
           systemd-homed,
           systemd-userdbd,
-          systemd-boot-signed | systemd-boot,
+          systemd-boot,
           libfido2-1,
           libtss2-esys-3.0.2-0,
           libtss2-mu0,
@@ -456,9 +456,7 @@ Depends: ${shlibs:Depends},
          systemd-boot-efi (= ${binary:Version}),
 Recommends: efibootmgr,
 Breaks: systemd (<< 251.2-3~)
-Replaces: systemd (<< 251.2-3~),
-          systemd-boot-signed
-Conflicts: systemd-boot-signed
+Replaces: systemd (<< 251.2-3~)
 Description: simple UEFI boot manager - tools and services
  systemd-boot (short: sd-boot) is a simple UEFI boot manager. It provides a
  textual menu to select the entry to boot and an editor for the kernel command


### PR DESCRIPTION
Debian's new systemd (since 251.2-3) places the EFI stub into systemd-boot-efi package. So, going to sign it as systemd-boot-efi-signed to be installed.

https://phabricator.endlessm.com/T33862