### PR TITLE
Revert "[Endless] sd-boot: Work around odd behaviour in some firmware"

### DIFF
--- a/src/boot/efi/boot.c
+++ b/src/boot/efi/boot.c
@@ -31,11 +31,6 @@
 
 #define TEXT_ATTR_SWAP(c) EFI_TEXT_ATTR(((c) & 0b11110000) >> 4, (c) & 0b1111)
 
-/* Some BIOSes scan the boot loader binary for the string "Microsoft" and
- * deliver broken ACPI tables if it's not present.
- */
-const char bios_confuser[] = "Microsoft";
-
 /* Magic string for recognizing our own binaries */
 _used_ _section_(".sdmagic") static const char magic[] =
         "#### LoaderInfo: systemd-boot " GIT_VERSION " ####";

--- a/src/boot/efi/meson.build
+++ b/src/boot/efi/meson.build
@@ -170,17 +170,6 @@ elif get_option('sbat-distro') != ''
         endif
 endif
 
-                # Check to make sure nothing has elided the "Microsoft"
-                # string we injected into systemd-boot
-                if want_tests != 'false'
-                        if tuple[0] == 'systemd_boot.so'
-                                ms_test_sh = find_program('ms_test.sh')
-                                test('Microsoft string present',
-                                     ms_test_sh,
-                                     args : [stub])
-                        endif
-                endif
-
 efi_config_h = configure_file(
         output : 'efi_config.h',
         configuration : efi_conf)

--- a/src/boot/efi/ms_test.sh
+++ b/src/boot/efi/ms_test.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-echo Looking for string \'Microsoft\' in "$1"
-grep Microsoft "$1"


### PR DESCRIPTION
This reverts commit 855dd915b15345ef597515339479aa4c8350b22b.

Drop for ECS EF20EA since EOS 5+

https://phabricator.endlessm.com/T33759