### PR TITLE
Revert "[DEB] Bring tmpfiles.d/tmp.conf in line with Debian defaults"

### DIFF
--- a/tmpfiles.d/tmp.conf
+++ b/tmpfiles.d/tmp.conf
@@ -8,5 +8,5 @@
 # See tmpfiles.d(5) for details
 
 # Clear tmp directories separately, to make them easier to override
-D /tmp 1777 root root -
-#q /var/tmp 1777 root root 30d
+q /tmp 1777 root root 10d
+q /var/tmp 1777 root root 30d


### PR DESCRIPTION
This reverts commit 97461254ad826ac7a36f6ea7e181c8e65cc6a98f.

Debian's policy is to never clean-up /var/tmp to keep consistency with the SysV init system. Flatpak creates temporary files in /var/tmp during app updates but does not remove them on error, to avoid re-downloading them on a future update attempt, and expects these files to be automatically cleaned-up by the system eventually, according to the site's policy. With this policy in place these files are never removed, wasting the user's storage space.

Revert this commit back to upstream's default policy of cleaning up /tmp every 10 days and /var/tmp every 30 days.

https://phabricator.endlessm.com/T23762
https://phabricator.endlessm.com/T33887