### PR TITLE
meson: Fix build with --optimization=plain

### DIFF
--- a/src/boot/efi/meson.build
+++ b/src/boot/efi/meson.build
@@ -215,7 +215,7 @@ endif
 if get_option('debug') and get_option('mode') == 'developer'
         efi_cflags += ['-ggdb', '-DEFI_DEBUG']
 endif
-if get_option('optimization') != '0'
+if get_option('optimization') in ['1', '2', '3', 's', 'g']
         efi_cflags += ['-O' + get_option('optimization')]
 endif
 if get_option('b_ndebug') == 'true' or (


### PR DESCRIPTION
Note that -O0 is deliberately filtered out as we have to compile with at least -O1 due to #24202.

Fixes: #24323
(cherry picked from commit 7aa4762ce274a1c9a59902b972fa4fdee1b22715)

This is a backport from upstream that's needed now that meson got updated to 1.0.