### PR TITLE
gpt-auto-generator: mount ESP when LoaderDevicePartUUID isn't set

### DIFF
--- a/src/boot/efi/meson.build
+++ b/src/boot/efi/meson.build
@@ -215,7 +215,7 @@ endif
 if get_option('debug') and get_option('mode') == 'developer'
         efi_cflags += ['-ggdb', '-DEFI_DEBUG']
 endif
-if get_option('optimization') != '0'
+if get_option('optimization') in ['1', '2', '3', 's', 'g']
         efi_cflags += ['-O' + get_option('optimization')]
 endif
 if get_option('b_ndebug') == 'true' or (

--- a/src/gpt-auto-generator/gpt-auto-generator.c
+++ b/src/gpt-auto-generator/gpt-auto-generator.c
@@ -561,17 +561,16 @@ static int add_esp(DissectedPartition *p, bool has_xbootldr) {
         if (is_efi_boot()) {
                 sd_id128_t loader_uuid;
 
-                /* If this is an EFI boot, be extra careful, and only mount the ESP if it was the ESP used for booting. */
+                /* If this is an EFI boot and the bootloader has set LoaderDevicePartUUID, only mount the ESP
+                 * if it was the ESP used for booting. */
 
                 r = efi_loader_get_device_part_uuid(&loader_uuid);
-                if (r == -ENOENT) {
-                        log_debug("EFI loader partition unknown.");
-                        return 0;
-                }
-                if (r < 0)
+                if (r < 0 && r != -ENOENT)
                         return log_error_errno(r, "Failed to read ESP partition UUID: %m");
 
-                if (!sd_id128_equal(p->uuid, loader_uuid)) {
+                if (r == -ENOENT)
+                        log_debug("EFI loader partition unknown, assuming %s was the booted ESP.", p->node);
+                else if (!sd_id128_equal(p->uuid, loader_uuid)) {
                         log_debug("Partition for %s does not appear to be the partition we are booted from.", p->node);
                         return 0;
                 }


### PR DESCRIPTION
If LoaderDevicePartUUID isn't set because the boot loader doesn't support it,
assume that the ESP partition on the root disk is the booted ESP. This is a
weaker guarantee but likely the same for the vast majority of systems. Allowing
the ESP automount in this case helps break a dependency loop. Existing boot
loaders can be changed to set LoaderDevicePartUUID, but they can't be delivered
to existing systems if the ESP is not mounted.

Upstream: https://github.com/systemd/systemd/pull/26430

https://phabricator.endlessm.com/T29930

This is on top of #163. I sent this upstream, but I doubt it's going to get merged. For Endless I think this makes sense to bootstrap updating EFI programs so that eventually we can have a grub that supports `LoaderDevicePartUUID`.

@wjt pointed out that this probably won't work right on dual boot systems. I think that should be managed separately. Possibly we can add in a custom generator for that scenario.