### PR TITLE
bootctl install only ESP binaries

### DIFF
--- a/src/boot/bootctl.c
+++ b/src/boot/bootctl.c
@@ -773,14 +773,11 @@ static const char *const esp_subdirs[] = {
         "EFI",
         "EFI/systemd",
         "EFI/BOOT",
-        "loader",
         NULL
 };
 
 static const char *const dollar_boot_subdirs[] = {
         /* The directories to place in the XBOOTLDR partition or the ESP, depending what exists */
-        "loader",
-        "loader/entries",  /* Type #1 entries */
         "EFI",
         "EFI/Linux",       /* Type #2 entries */
         NULL
@@ -1941,28 +1938,6 @@ static int verb_install(int argc, char *argv[], void *userdata) {
                 }
 
                 r = install_binaries(arg_esp_path, install);
-                if (r < 0)
-                        return r;
-
-                if (install) {
-                        r = install_loader_config(arg_esp_path);
-                        if (r < 0)
-                                return r;
-
-                        r = install_entry_directory(arg_dollar_boot_path());
-                        if (r < 0)
-                                return r;
-
-                        r = install_entry_token();
-                        if (r < 0)
-                                return r;
-
-                        r = install_random_seed(arg_esp_path);
-                        if (r < 0)
-                                return r;
-                }
-
-                r = install_loader_specification(arg_dollar_boot_path());
                 if (r < 0)
                         return r;
         }

--- a/src/boot/efi/boot.c
+++ b/src/boot/efi/boot.c
@@ -1624,9 +1624,9 @@ static void config_load_defaults(Config *config, EFI_FILE *root_dir) {
                 .timeout_sec_efivar = TIMEOUT_UNSET,
         };
 
-        link = resolve_link(root_dir, L"\\loader", L"\\entries");
+        link = resolve_link(root_dir, L"\\loader", L"\\loader.conf");
         if (!link)
-          link = L"\\loader\\entries";
+          link = L"\\loader\\loader.conf";
         err = file_read(root_dir, link, 0, 0, &content, NULL);
         if (!EFI_ERROR(err))
                 config_defaults_load_from_file(config, content);


### PR DESCRIPTION
We'd like to use `bootctl install` so that `bootctl update` recognizes the installation and makes updates. However, the install as performed now could cause issues with the `loader.sln` fake symlink scheme used for handling atomic ostree updates. Strip down the installation so it just manages the ESP binaries. None of the other parts are required and our systems haven't used them to this point.

https://phabricator.endlessm.com/T34703