### PR TITLE
fixup! [Endless] sd-boot: Read fake symlinks

### DIFF
--- a/src/boot/efi/boot.c
+++ b/src/boot/efi/boot.c
@@ -1584,7 +1584,7 @@ static char16_t *resolve_link(
         strcpy16(linkname + strlen16(linkname), L".sln");
 
         err = file_read(root_dir, linkname, 0, 0, &contents, NULL);
-        if (EFIERR(err))
+        if (err != EFI_SUCCESS)
                 return NULL;
 
         target = xstr8_to_path(contents);


### PR DESCRIPTION
Fix with the new error handling for new systemd-boot.

https://phabricator.endlessm.com/T35070