### PR TITLE
Revert "[Endless] sleep.conf: Disable hibernate and hybrid-sleep by default"

### DIFF
--- a/src/sleep/sleep.conf
+++ b/src/sleep/sleep.conf
@@ -14,9 +14,9 @@
 
 [Sleep]
 #AllowSuspend=yes
-AllowHibernation=No
-AllowSuspendThenHibernate=No
-AllowHybridSleep=No
+#AllowHibernation=yes
+#AllowSuspendThenHibernate=yes
+#AllowHybridSleep=yes
 #SuspendMode=
 #SuspendState=mem standby freeze
 #HibernateMode=platform shutdown


### PR DESCRIPTION
This reverts commit 742be08f3badd35fa146c25b61fb23690dd658c1.

Hibernation is availabe only when secure boot is disabled. However, disabled secure boot is not EOS' common case. Let users choose preferred configuration for suspend by themselves. So, revert the downstream modification.

More detail discussion: https://phabricator.endlessm.com/T35070#990597