### PR TITLE
hwdb: Enable JP-IK LEAP W502's touchpad toggle key

### DIFF
--- a/hwdb.d/60-keyboard.hwdb
+++ b/hwdb.d/60-keyboard.hwdb
@@ -915,6 +915,14 @@ evdev:atkbd:dmi:bvn*:bvr*:bd*:svnINVENTEC:pnSYMPHONY*6.0/7.0:*
  KEYBOARD_KEY_f4=prog1
 
 ###########################################################
+# JP-IK
+###########################################################
+
+# LEAP W502
+evdev:atkbd:dmi:bvn*:bvr*:bd*:svnJP-IK:pnLEAPW502:pvr*
+ KEYBOARD_KEY_76=f21                                    # touchpad toggle
+
+###########################################################
 # Lenovo
 ###########################################################
 


### PR DESCRIPTION
The laptop JP-IK LEAP W502 has touchpad toggle key (Fn+F9), but it does not work. Because, the scancode maps to a wrong key code:
```
Event: time 1715846095.224900, type 4 (EV_MSC), code 4 (MSC_SCAN), value 9d
Event: time 1715846095.224900, type 1 (EV_KEY), code 97 (KEY_RIGHTCTRL), value 1
Event: time 1715846095.224900, -------------- SYN_REPORT ------------
Event: time 1715846095.230985, type 4 (EV_MSC), code 4 (MSC_SCAN), value db
Event: time 1715846095.230985, type 1 (EV_KEY), code 125 (KEY_LEFTMETA), value 1
Event: time 1715846095.230985, -------------- SYN_REPORT ------------
Event: time 1715846095.232903, type 4 (EV_MSC), code 4 (MSC_SCAN), value 76
Event: time 1715846095.232903, type 1 (EV_KEY), code 85 (KEY_ZENKAKUHANKAKU), value 1
Event: time 1715846095.232903, -------------- SYN_REPORT ------------
```
Map the scancode 76 to KEY_F21 to enable the touchpad toggle key.

https://phabricator.endlessm.com/T35376