### PR TITLE
basic: Add new kernel fs

### DIFF
--- a/src/basic/filesystems-gperf.gperf
+++ b/src/basic/filesystems-gperf.gperf
@@ -91,6 +91,7 @@ ocfs2,           {OCFS2_SUPER_MAGIC}
 openpromfs,      {OPENPROM_SUPER_MAGIC}
 orangefs,        {ORANGEFS_DEVREQ_MAGIC}
 overlay,         {OVERLAYFS_SUPER_MAGIC}
+pidfs,           {PID_FS_MAGIC}
 pipefs,          {PIPEFS_MAGIC}
 ppc-cmm,         {PPC_CMM_MAGIC}
 proc,            {PROC_SUPER_MAGIC}

--- a/src/basic/filesystems-gperf.gperf
+++ b/src/basic/filesystems-gperf.gperf
@@ -28,6 +28,7 @@ afs,             {AFS_FS_MAGIC, AFS_SUPER_MAGIC}
 anon_inodefs,    {ANON_INODE_FS_MAGIC}
 autofs,          {AUTOFS_SUPER_MAGIC}
 balloon-kvm,     {BALLOON_KVM_MAGIC}
+bcachefs,        {BCACHEFS_SUPER_MAGIC}
 bdev,            {BDEVFS_MAGIC}
 binder,          {BINDERFS_SUPER_MAGIC}
 binfmt_misc,     {BINFMTFS_MAGIC}

--- a/src/basic/missing_magic.h
+++ b/src/basic/missing_magic.h
@@ -128,6 +128,11 @@
 #define DEVMEM_MAGIC 0x454d444d
 #endif
 
+/* cb12fd8e0dabb9a1c8aef55a6a41e2c255fcdf4b (6.8) */
+#ifndef PID_FS_MAGIC
+#define PID_FS_MAGIC 0x50494446
+#endif
+
 /* Not in mainline but included in Ubuntu */
 #ifndef SHIFTFS_MAGIC
 #define SHIFTFS_MAGIC 0x6a656a62

--- a/src/basic/missing_magic.h
+++ b/src/basic/missing_magic.h
@@ -197,3 +197,8 @@
 #ifndef NTFS3_SUPER_MAGIC
 #define NTFS3_SUPER_MAGIC 0x7366746e
 #endif
+
+/* Added in Linux commit e2f48c48090dea172c0c571101041de64634dae5. Remove when next sync'd */
+#ifndef BCACHEFS_SUPER_MAGIC
+#define BCACHEFS_SUPER_MAGIC 0xca451a4e
+#endif


### PR DESCRIPTION
basic: Add PIDFS and BCACHEFS magic to fix error:
```
../../src/basic/meson.build:234:8: ERROR: Problem encountered: Unknown filesystems defined in kernel headers:

Filesystem found in kernel header but not in filesystems-gperf.gperf: BCACHEFS_SUPER_MAGIC
Filesystem found in kernel header but not in filesystems-gperf.gperf: PID_FS_MAGIC
```

https://phabricator.endlessm.com/T35822