### PR TITLE
Revert "Create locale config file and compat symlink"

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -238,11 +238,6 @@ ifeq ($(DEB_VENDOR),Ubuntu)
 	cp -a debian/extra/units-ubuntu/* debian/systemd/lib/systemd/system/
 endif
 
-	# Endless specific files
-ifeq ($(DEB_VENDOR),Endless)
-	echo "LANG=en_US.utf8" > debian/systemd/etc/locale.conf
-endif
-
 execute_after_dh_installman-arch:
 	# remove duplicate files shipped by systemd-*/udev
 	# run after dh_installman, which runs after dh_install, to include manpages

--- a/debian/systemd.links
+++ b/debian/systemd.links
@@ -31,6 +31,3 @@
 
 # Create a compat symlink as systemd-sysctl no longer reads /etc/sysctl.conf
 /etc/sysctl.conf /etc/sysctl.d/99-sysctl.conf
-
-# Store locale info in just 1 place, but add a compat symlink.
-/etc/locale.conf /etc/default/locale


### PR DESCRIPTION
This reverts commit f0c12127f83e3d4769a49178dd55e2cae423fc6c.

To reduce the downstream modification, move the locale related modification to eos-boot-helper [1].

[1]: https://github.com/endlessm/eos-boot-helper/pull/421

https://phabricator.endlessm.com/T35837